### PR TITLE
Supporting Hostname Verification based on a configuration

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/pom.xml
@@ -56,6 +56,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity</groupId>
+            <artifactId>org.wso2.carbon.identity.base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity</groupId>
             <artifactId>org.wso2.carbon.identity.core</artifactId>
         </dependency>
         <dependency>
@@ -94,6 +98,7 @@
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.idp.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.identity.base;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.utils.*;version="${carbon.kernel.package.import.version.range}",
                             org.owasp.encoder; version ="${encoder.wso2.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveRequestorConstants.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveRequestorConstants.java
@@ -61,6 +61,8 @@ public class PassiveRequestorConstants {
 
     public static final String PASSIVE_ADDITIONAL_PARAMETER = "<!--$additionalParams-->";
 
+    public static final String RELYING_PARTY_REALMS = "realms";
+
     private PassiveRequestorConstants() {
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,9 @@
     </dependencyManagement>
 
     <properties>
+        <identity.framework.version>5.1.1-SNAPSHOT</identity.framework.version>
+        <carbon.identity.package.export.version>${project.version}</carbon.identity.package.export.version>
+
         <carbon.xfer.package.version>4.2.0</carbon.xfer.package.version>
         <inbound.oauth.openid.version>5.1.0</inbound.oauth.openid.version>
         <identity.sts.mgt.stub.version>5.1.1-SNAPSHOT</identity.sts.mgt.stub.version>


### PR DESCRIPTION
Passive STS SLO requests for service providers were initiated without hostname verification and certificate validation which imposes a security risk.
Thus, this fix ensures certificate validation always, and enables host name verification by default and allows to turn it off by adding following configuration in the repository/conf/identity/identity.xml file under Server\PassiveSTS tag.

<SLOHostNameVerificationEnabled>false</SLOHostNameVerificationEnabled>

Depends on https://github.com/wso2/carbon-identity-framework/pull/415 and https://github.com/wso2/carbon-identity-framework/pull/416