### PR TITLE
IDENTITY-4819 : SSO flow is not working as expected in chrome

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
@@ -198,6 +198,7 @@ public class PassiveSTS extends HttpServlet {
                             Encode.forHtmlAttribute(authenticatedIdPs) + "'>");
         }
 
+        httpResp.setContentType("text/html; charset=UTF-8");
         PrintWriter out = httpResp.getWriter();
         out.print(finalPage);
 


### PR DESCRIPTION
X-Content-Type-Options header is now enforced. Chrome and IE supports this header and expects 'Content-Type' header always.