### PR TITLE
Tenant Qualify outbound URLs of Passive-STS 

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/pom.xml
@@ -224,6 +224,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
@@ -40,6 +40,8 @@ import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.sts.passive.stub.types.RequestToken;
 import org.wso2.carbon.identity.sts.passive.stub.types.ResponseToken;
@@ -345,9 +347,21 @@ public class PassiveSTS extends HttpServlet {
     private void sendToAuthenticationFramework(HttpServletRequest request, HttpServletResponse response,
                                                String sessionDataKey, SessionDTO sessionDTO) throws IOException {
 
-        String commonAuthURL = IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, false, true);
+        String commonAuthURL;
+        try {
+            commonAuthURL = ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH).build()
+                    .getAbsolutePublicURL();
+        } catch (URLBuilderException e) {
+            throw new IOException("Error occurred while building the commonauth URL during login.", e);
+        }
 
-        String selfPath = request.getRequestURI();
+        String selfPath;
+        try {
+            selfPath = ServiceURLBuilder.create().addPath(request.getRequestURI()).build().getRelativeInternalURL();
+        } catch (URLBuilderException e) {
+            throw new IOException("Error occurred while building the commonauth caller path URL during login.", e);
+        }
+
         //Authentication context keeps data which should be sent to commonAuth endpoint
         AuthenticationRequest authenticationRequest = new AuthenticationRequest();
         authenticationRequest.setRelyingParty(sessionDTO.getRealm());

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTSException.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTSException.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.identity.sts.passive.ui;
+
+import org.wso2.carbon.identity.base.IdentityException;
+
+/**
+ * Exception to handle Passive STS related error.
+ */
+public class PassiveSTSException extends IdentityException {
+
+    public PassiveSTSException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/features/org.wso2.carbon.identity.sts.passive.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.sts.passive.server.feature/pom.xml
@@ -38,11 +38,6 @@
             <artifactId>org.wso2.carbon.identity.sts.passive</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.application.authentication.endpoint</artifactId>
-            <type>war</type>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -279,12 +279,6 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.application.authentication.endpoint</artifactId>
-                <version>${identity.framework.version}</version>
-                <type>war</type>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-core</artifactId>
                 <version>${cxf-bundle.version}</version>
@@ -436,7 +430,7 @@
     </build>
 
     <properties>
-        <identity.framework.version>5.14.67</identity.framework.version>
+        <identity.framework.version>5.17.77</identity.framework.version>
         <identity.inbound.auth.sts.package.export.version>${project.version}
         </identity.inbound.auth.sts.package.export.version>
         <inbound.auth.openid.version>5.4.0</inbound.auth.openid.version>


### PR DESCRIPTION
### Proposed changes in this pull request
- Related to https://github.com/wso2/product-is/issues/8314
- Tenant qualify outbound URLs of passive STS login and logout flows. 
- Removed the dependency of org.wso2.carbon.identity.application.authentication.endpoint since this is no longer a valid one[1] and no usages found.

To enable this behaviour, the below config needs to be added to deployement.toml
```
[tenant_context]
enable_tenant_qualified_urls = "true"
```

This PR depends on https://github.com/wso2/carbon-identity-framework/pull/2930

[1] https://github.com/wso2/carbon-identity-framework/tree/master/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint  

