### PR TITLE
Tenant Qualify inbound URLs of Passive-STS

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/pom.xml
@@ -224,6 +224,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
@@ -175,15 +175,22 @@ public class PassiveSTS extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 
-
         String sessionDataKey = req.getParameter(SESSION_DATA_KEY);
         if (sessionDataKey != null) {
             handleResponseFromAuthenticationFramework(req, resp);
             FrameworkUtils.removeAuthenticationResultFromCache(sessionDataKey);
         } else if ("wsignout1.0".equals(getAttribute(req.getParameterMap(), PassiveRequestorConstants.ACTION))) {
-            handleLogoutRequest(req, resp);
+            try {
+                handleLogoutRequest(req, resp);
+            } catch (PassiveSTSException e) {
+                log.error("Error occurred while handling the Passive STS logout request.", e);
+            }
         } else {
-            handleAuthenticationRequest(req, resp);
+            try {
+                handleAuthenticationRequest(req, resp);
+            } catch (PassiveSTSException e) {
+                log.error("Error occurred while handling the Passive STS authentication request.", e);
+            }
         }
     }
 
@@ -345,22 +352,18 @@ public class PassiveSTS extends HttpServlet {
     }
 
     private void sendToAuthenticationFramework(HttpServletRequest request, HttpServletResponse response,
-                                               String sessionDataKey, SessionDTO sessionDTO) throws IOException {
+                                               String sessionDataKey, SessionDTO sessionDTO)
+            throws IOException, PassiveSTSException {
 
         String commonAuthURL;
         try {
             commonAuthURL = ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH).build()
                     .getAbsolutePublicURL();
         } catch (URLBuilderException e) {
-            throw new IOException("Error occurred while building the commonauth URL during login.", e);
+            throw new PassiveSTSException("Error occurred while building the commonauth URL during login.", e);
         }
 
-        String selfPath;
-        try {
-            selfPath = ServiceURLBuilder.create().addPath(request.getRequestURI()).build().getRelativeInternalURL();
-        } catch (URLBuilderException e) {
-            throw new IOException("Error occurred while building the commonauth caller path URL during login.", e);
-        }
+        String selfPath = request.getRequestURI();
 
         //Authentication context keeps data which should be sent to commonAuth endpoint
         AuthenticationRequest authenticationRequest = new AuthenticationRequest();
@@ -480,7 +483,8 @@ public class PassiveSTS extends HttpServlet {
         }
     }
 
-    private void handleLogoutRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    private void handleLogoutRequest(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, PassiveSTSException {
 
         // wreply parameter is optional for the logout request. So we are setting that value from the service
         // provider configuration in case it is not available in the request.
@@ -553,7 +557,9 @@ public class PassiveSTS extends HttpServlet {
         }
     }
 
-    private void sendFrameworkForLogout(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    private void sendFrameworkForLogout(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException, PassiveSTSException {
+
         Map paramMap = request.getParameterMap();
         SessionDTO sessionDTO = new SessionDTO();
         sessionDTO.setAction(getAttribute(paramMap, PassiveRequestorConstants.ACTION));
@@ -569,7 +575,13 @@ public class PassiveSTS extends HttpServlet {
 
         String sessionDataKey = UUIDGenerator.generateUUID();
         addSessionDataToCache(sessionDataKey, sessionDTO);
-        String commonAuthURL = IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, false, true);
+        String commonAuthURL = null;
+        try {
+            commonAuthURL = ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH).build()
+                    .getAbsolutePublicURL();
+        } catch (URLBuilderException e) {
+            throw new PassiveSTSException("Error occurred while building the commonauth URL during logout.", e);
+        }
 
         String selfPath = request.getRequestURI();
         AuthenticationRequest authenticationRequest = new AuthenticationRequest();
@@ -598,7 +610,7 @@ public class PassiveSTS extends HttpServlet {
     }
 
     private void handleAuthenticationRequest(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
+            throws IOException, ServletException, PassiveSTSException {
 
         Map paramMap = request.getParameterMap();
 

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
@@ -40,6 +40,8 @@ import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.sts.passive.stub.types.RequestToken;
 import org.wso2.carbon.identity.sts.passive.stub.types.ResponseToken;
@@ -345,9 +347,21 @@ public class PassiveSTS extends HttpServlet {
     private void sendToAuthenticationFramework(HttpServletRequest request, HttpServletResponse response,
                                                String sessionDataKey, SessionDTO sessionDTO) throws IOException {
 
-        String commonAuthURL = IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, false, true);
+        String commonAuthURL;
+        try {
+            commonAuthURL = ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH).build()
+                    .getAbsolutePublicURL();
+        } catch (URLBuilderException e) {
+            throw new IOException("Error occurred while building the commonauth URL during login.", e);
+        }
 
-        String selfPath = request.getRequestURI();
+        String selfPath;
+        try {
+            selfPath = ServiceURLBuilder.create().addPath(request.getRequestURI()).build().getRelativeInternalURL();
+        } catch (URLBuilderException e) {
+            throw new IOException("Error occurred while building the commonauth caller path URL during login.", e);
+        }
+
         //Authentication context keeps data which should be sent to commonAuth endpoint
         AuthenticationRequest authenticationRequest = new AuthenticationRequest();
         authenticationRequest.setRelyingParty(sessionDTO.getRealm());

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.sts.passive.stub.types.RequestToken;
 import org.wso2.carbon.identity.sts.passive.stub.types.ResponseToken;
@@ -107,6 +108,7 @@ public class PassiveSTS extends HttpServlet {
     private static final String HTTPS = "https";
     private static final String PASSIVE_STS_CLIENT_TYPE = "passivests";
     private static final String PASSIVE_STS_W_REPLY_PROPERTY = "passiveSTSWReply";
+    private static final String PASSIVE_STS_EP_URL = "/passivests";
 
     /**
      * This method reads Passive STS Html Redirect file content.
@@ -352,7 +354,7 @@ public class PassiveSTS extends HttpServlet {
     }
 
     private void sendToAuthenticationFramework(HttpServletRequest request, HttpServletResponse response,
-                                               String sessionDataKey, SessionDTO sessionDTO)
+                                               String sessionDataKey, SessionDTO sessionDTO, String tenantDomain)
             throws IOException, PassiveSTSException {
 
         String commonAuthURL;
@@ -363,7 +365,12 @@ public class PassiveSTS extends HttpServlet {
             throw new PassiveSTSException("Error occurred while building the commonauth URL during login.", e);
         }
 
-        String selfPath = request.getRequestURI();
+        String selfPath;
+        try {
+            selfPath = ServiceURLBuilder.create().addPath(PASSIVE_STS_EP_URL).build().getRelativeInternalURL();
+        } catch (URLBuilderException e) {
+            throw new PassiveSTSException("Error occurred while building commonauth caller path URL during login.", e);
+        }
 
         //Authentication context keeps data which should be sent to commonAuth endpoint
         AuthenticationRequest authenticationRequest = new AuthenticationRequest();
@@ -371,6 +378,7 @@ public class PassiveSTS extends HttpServlet {
         authenticationRequest.setCommonAuthCallerPath(selfPath);
         authenticationRequest.setForceAuth(false);
         authenticationRequest.setRequestQueryParams(request.getParameterMap());
+        authenticationRequest.setTenantDomain(tenantDomain);
 
         //adding headers in out going request to authentication request context
         for (Enumeration e = request.getHeaderNames(); e.hasMoreElements(); ) {
@@ -561,17 +569,8 @@ public class PassiveSTS extends HttpServlet {
             throws ServletException, IOException, PassiveSTSException {
 
         Map paramMap = request.getParameterMap();
-        SessionDTO sessionDTO = new SessionDTO();
-        sessionDTO.setAction(getAttribute(paramMap, PassiveRequestorConstants.ACTION));
-        sessionDTO.setAttributes(getAttribute(paramMap, PassiveRequestorConstants.ATTRIBUTE));
-        sessionDTO.setContext(getAttribute(paramMap, PassiveRequestorConstants.CONTEXT));
-        sessionDTO.setReplyTo(getAttribute(paramMap, PassiveRequestorConstants.REPLY_TO));
-        sessionDTO.setPseudo(getAttribute(paramMap, PassiveRequestorConstants.PSEUDO));
-        sessionDTO.setRealm(getAttribute(paramMap, PassiveRequestorConstants.REALM));
-        sessionDTO.setRequest(getAttribute(paramMap, PassiveRequestorConstants.REQUEST));
-        sessionDTO.setRequestPointer(getAttribute(paramMap, PassiveRequestorConstants.REQUEST_POINTER));
-        sessionDTO.setPolicy(getAttribute(paramMap, PassiveRequestorConstants.POLCY));
-        sessionDTO.setReqQueryString(request.getQueryString());
+        String tenantDomain = resolveTenantDomain(paramMap);
+        SessionDTO sessionDTO = buildSessionDTO(paramMap, tenantDomain, request.getQueryString());
 
         String sessionDataKey = UUIDGenerator.generateUUID();
         addSessionDataToCache(sessionDataKey, sessionDTO);
@@ -583,13 +582,20 @@ public class PassiveSTS extends HttpServlet {
             throw new PassiveSTSException("Error occurred while building the commonauth URL during logout.", e);
         }
 
-        String selfPath = request.getRequestURI();
+        String selfPath;
+        try {
+            selfPath = ServiceURLBuilder.create().addPath(PASSIVE_STS_EP_URL).build().getRelativeInternalURL();
+        } catch (URLBuilderException e) {
+            throw new PassiveSTSException("Error occurred while building commonauth caller path URL during logout.", e);
+        }
+
         AuthenticationRequest authenticationRequest = new AuthenticationRequest();
         authenticationRequest.addRequestQueryParam(FrameworkConstants.RequestParams.LOGOUT,
                 new String[]{Boolean.TRUE.toString()});
         authenticationRequest.setRequestQueryParams(request.getParameterMap());
         authenticationRequest.setCommonAuthCallerPath(selfPath);
         authenticationRequest.appendRequestQueryParams(request.getParameterMap());
+        authenticationRequest.setTenantDomain(tenantDomain);
         // According to ws-federation-1.2-spec; 'wtrealm' will not be sent in the Passive STS Logout Request.
         if (sessionDTO.getRealm() == null || sessionDTO.getRealm().trim().length() == 0) {
             authenticationRequest.setRelyingParty(new String());
@@ -613,6 +619,36 @@ public class PassiveSTS extends HttpServlet {
             throws IOException, ServletException, PassiveSTSException {
 
         Map paramMap = request.getParameterMap();
+        String tenantDomain = resolveTenantDomain(paramMap);
+        SessionDTO sessionDTO = buildSessionDTO(paramMap, tenantDomain, request.getQueryString());
+
+        String sessionDataKey = UUIDGenerator.generateUUID();
+        addSessionDataToCache(sessionDataKey, sessionDTO);
+
+        sendToAuthenticationFramework(request, response, sessionDataKey, sessionDTO, tenantDomain);
+    }
+
+    private String resolveTenantDomain(Map paramMap) {
+
+        String tenantDomain = null;
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+            if (log.isDebugEnabled()) {
+                log.debug("Tenant domain from context: " + tenantDomain);
+            }
+        }
+
+        if (StringUtils.isBlank(tenantDomain)) {
+            tenantDomain = getAttribute(paramMap, MultitenantConstants.TENANT_DOMAIN);
+            if (log.isDebugEnabled()) {
+                log.debug("Tenant domain not available in context. Tenant domain from query param: " +
+                        tenantDomain);
+            }
+        }
+        return tenantDomain;
+    }
+
+    private SessionDTO buildSessionDTO(Map paramMap, String tenantDomain, String queryString) {
 
         SessionDTO sessionDTO = new SessionDTO();
         sessionDTO.setAction(getAttribute(paramMap, PassiveRequestorConstants.ACTION));
@@ -624,13 +660,10 @@ public class PassiveSTS extends HttpServlet {
         sessionDTO.setRequest(getAttribute(paramMap, PassiveRequestorConstants.REQUEST));
         sessionDTO.setRequestPointer(getAttribute(paramMap, PassiveRequestorConstants.REQUEST_POINTER));
         sessionDTO.setPolicy(getAttribute(paramMap, PassiveRequestorConstants.POLCY));
-        sessionDTO.setTenantDomain(getAttribute(paramMap, MultitenantConstants.TENANT_DOMAIN));
-        sessionDTO.setReqQueryString(request.getQueryString());
+        sessionDTO.setTenantDomain(tenantDomain);
+        sessionDTO.setReqQueryString(queryString);
 
-        String sessionDataKey = UUIDGenerator.generateUUID();
-        addSessionDataToCache(sessionDataKey, sessionDTO);
-
-        sendToAuthenticationFramework(request, response, sessionDataKey, sessionDTO);
+        return sessionDTO;
     }
 
     private void addSessionDataToCache(String sessionDataKey, SessionDTO sessionDTO) {

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTSException.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTSException.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.identity.sts.passive.ui;
+
+import org.wso2.carbon.identity.base.IdentityException;
+
+/**
+ * Exception to handle Passive STS related error.
+ */
+public class PassiveSTSException extends IdentityException {
+
+    public PassiveSTSException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/features/org.wso2.carbon.identity.sts.passive.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.sts.passive.server.feature/pom.xml
@@ -38,11 +38,6 @@
             <artifactId>org.wso2.carbon.identity.sts.passive</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.application.authentication.endpoint</artifactId>
-            <type>war</type>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -279,12 +279,6 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.application.authentication.endpoint</artifactId>
-                <version>${identity.framework.version}</version>
-                <type>war</type>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-core</artifactId>
                 <version>${cxf-bundle.version}</version>
@@ -436,7 +430,7 @@
     </build>
 
     <properties>
-        <identity.framework.version>5.14.67</identity.framework.version>
+        <identity.framework.version>5.17.77</identity.framework.version>
         <identity.inbound.auth.sts.package.export.version>${project.version}
         </identity.inbound.auth.sts.package.export.version>
         <inbound.auth.openid.version>5.4.0</inbound.auth.openid.version>


### PR DESCRIPTION
### Proposed changes in this pull request
- Related to https://github.com/wso2/product-is/issues/8315
- Based on https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/91

To enable this behaviour, the below config needs to be added to deployement.toml
```
[tenant_context]
enable_tenant_qualified_urls = "true"
```

This PR depends on wso2/carbon-identity-framework#2930