### PR TITLE
Tenant qualify inbound URLs of Passive STS

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
@@ -568,7 +568,7 @@ public class PassiveSTS extends HttpServlet {
     private void sendFrameworkForLogout(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException, PassiveSTSException {
 
-        Map paramMap = request.getParameterMap();
+        Map<String, String[]> paramMap = request.getParameterMap();
         String tenantDomain = resolveTenantDomain(paramMap);
         SessionDTO sessionDTO = buildSessionDTO(paramMap, tenantDomain, request.getQueryString());
 
@@ -618,7 +618,7 @@ public class PassiveSTS extends HttpServlet {
     private void handleAuthenticationRequest(HttpServletRequest request, HttpServletResponse response)
             throws IOException, ServletException, PassiveSTSException {
 
-        Map paramMap = request.getParameterMap();
+        Map<String, String[]> paramMap = request.getParameterMap();
         String tenantDomain = resolveTenantDomain(paramMap);
         SessionDTO sessionDTO = buildSessionDTO(paramMap, tenantDomain, request.getQueryString());
 
@@ -628,27 +628,25 @@ public class PassiveSTS extends HttpServlet {
         sendToAuthenticationFramework(request, response, sessionDataKey, sessionDTO, tenantDomain);
     }
 
-    private String resolveTenantDomain(Map paramMap) {
+    private String resolveTenantDomain(Map<String, String[]> paramMap) {
 
-        String tenantDomain = null;
+        String tenantDomain;
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
             tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
             if (log.isDebugEnabled()) {
                 log.debug("Tenant domain from context: " + tenantDomain);
             }
+            return tenantDomain;
         }
 
-        if (StringUtils.isBlank(tenantDomain)) {
-            tenantDomain = getAttribute(paramMap, MultitenantConstants.TENANT_DOMAIN);
-            if (log.isDebugEnabled()) {
-                log.debug("Tenant domain not available in context. Tenant domain from query param: " +
-                        tenantDomain);
-            }
+        tenantDomain = getAttribute(paramMap, MultitenantConstants.TENANT_DOMAIN);
+        if (log.isDebugEnabled()) {
+            log.debug("Tenant domain from query param: " + tenantDomain);
         }
         return tenantDomain;
     }
 
-    private SessionDTO buildSessionDTO(Map paramMap, String tenantDomain, String queryString) {
+    private SessionDTO buildSessionDTO(Map<String, String[]> paramMap, String tenantDomain, String queryString) {
 
         SessionDTO sessionDTO = new SessionDTO();
         sessionDTO.setAction(getAttribute(paramMap, PassiveRequestorConstants.ACTION));

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.sts.passive.stub.types.RequestToken;
 import org.wso2.carbon.identity.sts.passive.stub.types.ResponseToken;
@@ -107,6 +108,7 @@ public class PassiveSTS extends HttpServlet {
     private static final String HTTPS = "https";
     private static final String PASSIVE_STS_CLIENT_TYPE = "passivests";
     private static final String PASSIVE_STS_W_REPLY_PROPERTY = "passiveSTSWReply";
+    private static final String PASSIVE_STS_EP_URL = "/passivests";
 
     /**
      * This method reads Passive STS Html Redirect file content.
@@ -352,7 +354,7 @@ public class PassiveSTS extends HttpServlet {
     }
 
     private void sendToAuthenticationFramework(HttpServletRequest request, HttpServletResponse response,
-                                               String sessionDataKey, SessionDTO sessionDTO)
+                                               String sessionDataKey, SessionDTO sessionDTO, String tenantDomain)
             throws IOException, PassiveSTSException {
 
         String commonAuthURL;
@@ -363,7 +365,12 @@ public class PassiveSTS extends HttpServlet {
             throw new PassiveSTSException("Error occurred while building the commonauth URL during login.", e);
         }
 
-        String selfPath = request.getRequestURI();
+        String selfPath;
+        try {
+            selfPath = ServiceURLBuilder.create().addPath(PASSIVE_STS_EP_URL).build().getRelativeInternalURL();
+        } catch (URLBuilderException e) {
+            throw new PassiveSTSException("Error occurred while building commonauth caller path URL during login.", e);
+        }
 
         //Authentication context keeps data which should be sent to commonAuth endpoint
         AuthenticationRequest authenticationRequest = new AuthenticationRequest();
@@ -371,6 +378,7 @@ public class PassiveSTS extends HttpServlet {
         authenticationRequest.setCommonAuthCallerPath(selfPath);
         authenticationRequest.setForceAuth(false);
         authenticationRequest.setRequestQueryParams(request.getParameterMap());
+        authenticationRequest.setTenantDomain(tenantDomain);
 
         //adding headers in out going request to authentication request context
         for (Enumeration e = request.getHeaderNames(); e.hasMoreElements(); ) {
@@ -561,17 +569,8 @@ public class PassiveSTS extends HttpServlet {
             throws ServletException, IOException, PassiveSTSException {
 
         Map paramMap = request.getParameterMap();
-        SessionDTO sessionDTO = new SessionDTO();
-        sessionDTO.setAction(getAttribute(paramMap, PassiveRequestorConstants.ACTION));
-        sessionDTO.setAttributes(getAttribute(paramMap, PassiveRequestorConstants.ATTRIBUTE));
-        sessionDTO.setContext(getAttribute(paramMap, PassiveRequestorConstants.CONTEXT));
-        sessionDTO.setReplyTo(getAttribute(paramMap, PassiveRequestorConstants.REPLY_TO));
-        sessionDTO.setPseudo(getAttribute(paramMap, PassiveRequestorConstants.PSEUDO));
-        sessionDTO.setRealm(getAttribute(paramMap, PassiveRequestorConstants.REALM));
-        sessionDTO.setRequest(getAttribute(paramMap, PassiveRequestorConstants.REQUEST));
-        sessionDTO.setRequestPointer(getAttribute(paramMap, PassiveRequestorConstants.REQUEST_POINTER));
-        sessionDTO.setPolicy(getAttribute(paramMap, PassiveRequestorConstants.POLCY));
-        sessionDTO.setReqQueryString(request.getQueryString());
+        String tenantDomain = resolveTenantDomain(paramMap);
+        SessionDTO sessionDTO = buildSessionDTO(paramMap, tenantDomain, request.getQueryString());
 
         String sessionDataKey = UUIDGenerator.generateUUID();
         addSessionDataToCache(sessionDataKey, sessionDTO);
@@ -583,13 +582,20 @@ public class PassiveSTS extends HttpServlet {
             throw new PassiveSTSException("Error occurred while building the commonauth URL during logout.", e);
         }
 
-        String selfPath = request.getRequestURI();
+        String selfPath;
+        try {
+            selfPath = ServiceURLBuilder.create().addPath(PASSIVE_STS_EP_URL).build().getRelativeInternalURL();
+        } catch (URLBuilderException e) {
+            throw new PassiveSTSException("Error occurred while building commonauth caller path URL during logout.", e);
+        }
+
         AuthenticationRequest authenticationRequest = new AuthenticationRequest();
         authenticationRequest.addRequestQueryParam(FrameworkConstants.RequestParams.LOGOUT,
                 new String[]{Boolean.TRUE.toString()});
         authenticationRequest.setRequestQueryParams(request.getParameterMap());
         authenticationRequest.setCommonAuthCallerPath(selfPath);
         authenticationRequest.appendRequestQueryParams(request.getParameterMap());
+        authenticationRequest.setTenantDomain(tenantDomain);
         // According to ws-federation-1.2-spec; 'wtrealm' will not be sent in the Passive STS Logout Request.
         if (sessionDTO.getRealm() == null || sessionDTO.getRealm().trim().length() == 0) {
             authenticationRequest.setRelyingParty(new String());
@@ -613,6 +619,36 @@ public class PassiveSTS extends HttpServlet {
             throws IOException, ServletException, PassiveSTSException {
 
         Map paramMap = request.getParameterMap();
+        String tenantDomain = resolveTenantDomain(paramMap);
+        SessionDTO sessionDTO = buildSessionDTO(paramMap, tenantDomain, request.getQueryString());
+
+        String sessionDataKey = UUIDGenerator.generateUUID();
+        addSessionDataToCache(sessionDataKey, sessionDTO);
+
+        sendToAuthenticationFramework(request, response, sessionDataKey, sessionDTO, tenantDomain);
+    }
+
+    private String resolveTenantDomain(Map paramMap) {
+
+        String tenantDomain = null;
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+            if (log.isDebugEnabled()) {
+                log.debug("Tenant domain from context: " + tenantDomain);
+            }
+        }
+
+        if (StringUtils.isBlank(tenantDomain)) {
+            tenantDomain = getAttribute(paramMap, MultitenantConstants.TENANT_DOMAIN);
+            if (log.isDebugEnabled()) {
+                log.debug("Tenant domain not available in context. Tenant domain from query param: " +
+                        tenantDomain);
+            }
+        }
+        return tenantDomain;
+    }
+
+    private SessionDTO buildSessionDTO(Map paramMap, String tenantDomain, String queryString) {
 
         SessionDTO sessionDTO = new SessionDTO();
         sessionDTO.setAction(getAttribute(paramMap, PassiveRequestorConstants.ACTION));
@@ -624,13 +660,10 @@ public class PassiveSTS extends HttpServlet {
         sessionDTO.setRequest(getAttribute(paramMap, PassiveRequestorConstants.REQUEST));
         sessionDTO.setRequestPointer(getAttribute(paramMap, PassiveRequestorConstants.REQUEST_POINTER));
         sessionDTO.setPolicy(getAttribute(paramMap, PassiveRequestorConstants.POLCY));
-        sessionDTO.setTenantDomain(getAttribute(paramMap, MultitenantConstants.TENANT_DOMAIN));
-        sessionDTO.setReqQueryString(request.getQueryString());
+        sessionDTO.setTenantDomain(tenantDomain);
+        sessionDTO.setReqQueryString(queryString);
 
-        String sessionDataKey = UUIDGenerator.generateUUID();
-        addSessionDataToCache(sessionDataKey, sessionDTO);
-
-        sendToAuthenticationFramework(request, response, sessionDataKey, sessionDTO);
+        return sessionDTO;
     }
 
     private void addSessionDataToCache(String sessionDataKey, SessionDTO sessionDTO) {


### PR DESCRIPTION
### Proposed changes in this pull request
- Related to wso2/product-is#8315
- Based on #91
To enable this behaviour, the below config needs to be added to deployement.toml
```
[tenant_context]
enable_tenant_qualified_urls = "true"
```
This PR depends on the config changes introduced at wso2/carbon-identity-framework#2930