### PR TITLE
Remove mex components from the connector and provide it to the default product

### DIFF
--- a/components/org.wso2.carbon.mex/pom.xml
+++ b/components/org.wso2.carbon.mex/pom.xml
@@ -87,7 +87,6 @@
                             javax.xml.stream; version="${equinox.osgi.stax-api.imp.pkg.version.range}",
                             org.apache.axiom.om; version="${axiom.osgi.version.range}",
                             org.apache.axis2.*; version="${axis2.osgi.version.range}",
-                            org.apache.rahas.impl; version="${rampart.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",

--- a/components/org.wso2.carbon.mex2/pom.xml
+++ b/components/org.wso2.carbon.mex2/pom.xml
@@ -87,7 +87,6 @@
                             javax.xml.stream; version="${equinox.osgi.stax-api.imp.pkg.version.range}",
                             org.apache.axiom.om; version="${axiom.osgi.version.range}",
                             org.apache.axis2.*; version="${axis2.osgi.version.range}",
-                            org.apache.rahas.impl; version="${rampart.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",

--- a/components/org.wso2.carbon.sts.connector/src/assembly/sts-connector.xml
+++ b/components/org.wso2.carbon.sts.connector/src/assembly/sts-connector.xml
@@ -55,19 +55,6 @@
             </includes>
         </dependencySet>
         <dependencySet>
-            <outputDirectory>wso2is-sts-connector-${project.version}/dropins/</outputDirectory>
-            <includes>
-                <include>org.wso2.carbon:org.wso2.carbon.xfer</include>
-            </includes>
-        </dependencySet>
-        <dependencySet>
-            <outputDirectory>wso2is-sts-connector-${project.version}/deployment-server-webapps/</outputDirectory>
-            <outputFileNameMapping>mexut.war</outputFileNameMapping>
-            <includes>
-                <include>org.wso2.carbon.identity.inbound.auth.sts:org.wso2.carbon.mex.endpoint</include>
-            </includes>
-        </dependencySet>
-        <dependencySet>
             <outputDirectory>wso2is-sts-connector-${project.version}/deployment-client-modules/</outputDirectory>
             <includes>
                 <include>org.apache.rampart:rampart</include>
@@ -101,18 +88,6 @@
         </file>
         <file>
             <source>
-                ../org.wso2.carbon.mex/target/org.wso2.carbon.mex-${project.version}.jar
-            </source>
-            <outputDirectory>wso2is-sts-connector-${project.version}/dropins/</outputDirectory>
-        </file>
-        <file>
-            <source>
-                ../org.wso2.carbon.mex2/target/org.wso2.carbon.mex2-${project.version}.jar
-            </source>
-            <outputDirectory>wso2is-sts-connector-${project.version}/dropins/</outputDirectory>
-        </file>
-        <file>
-            <source>
                 ../org.wso2.carbon.sts/target/org.wso2.carbon.sts-${project.version}.jar
             </source>
             <outputDirectory>wso2is-sts-connector-${project.version}/dropins/</outputDirectory>
@@ -134,12 +109,6 @@
                 ../org.wso2.carbon.security.sts.common/target/org.wso2.carbon.identity.sts.common-${project.version}.jar
             </source>
             <outputDirectory>wso2is-sts-connector-${project.version}/dropins/</outputDirectory>
-        </file>
-        <file>
-            <source>
-                ../../features/org.wso2.carbon.mex.feature/resources/metadata.xml
-            </source>
-            <outputDirectory>wso2is-sts-connector-${project.version}/deployment-server-webapps/</outputDirectory>
         </file>
         <file>
             <source>

--- a/components/org.wso2.carbon.sts.connector/src/main/resources/setup_sts.sh
+++ b/components/org.wso2.carbon.sts.connector/src/main/resources/setup_sts.sh
@@ -1,6 +1,3 @@
 #!/bin/bash
 mv ./dropins/* ../repository/components/dropins/
 mv ./deployment-client-modules/* ../repository/deployment/client/modules/
-mv ./deployment-server-webapps/mexut.war ../repository/deployment/server/webapps/
-mkdir ../repository/deployment/server/webapps/mex/
-mv ./deployment-server-webapps/metadata.xml ../repository/deployment/server/webapps/mex/


### PR DESCRIPTION
**Description:**

Remove mex components from the connector and add them to the default product since it is needed for passive sts(WS-Federation)

Fixes: https://github.com/wso2/product-is/issues/8350