### PR TITLE
Upgrade opensaml version to 3.3.1.wso2v6

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive/pom.xml
+++ b/components/org.wso2.carbon.identity.sts.passive/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.wso2.orbit.org.opensaml</groupId>
             <artifactId>opensaml</artifactId>
-            <version>3.3.1.wso2v3</version>
+            <version>3.3.1.wso2v6</version>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.logging</groupId>


### PR DESCRIPTION
### Proposed changes in this pull request
Upgrade opensaml version to 3.3.1.wso2v6 which upgrades org.owasp.esapi:esapi to 2.4.0.0 from 2.2.3.1