### PR TITLE
Set AttributeName in Passive STS responses

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/custom/provider/CustomAttributeProvider.java
+++ b/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/custom/provider/CustomAttributeProvider.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.carbon.identity.sts.passive.custom.provider;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.sts.claims.ClaimsUtils;
 import org.apache.cxf.sts.claims.ProcessedClaim;
 import org.apache.cxf.sts.claims.ProcessedClaimCollection;
@@ -71,14 +72,20 @@ public class CustomAttributeProvider implements AttributeStatementProvider {
         AttributeBean attributeBean = new AttributeBean();
         if (WSS4JConstants.WSS_SAML2_TOKEN_TYPE.equals(tokenType)
                 || WSS4JConstants.SAML2_NS.equals(tokenType)) {
-            attributeBean.setQualifiedName(claim.getClaimType());
             attributeBean.setNameFormat(claim.getClaimType());
-        } else {
-            attributeBean.setQualifiedName(claim.getClaimType());
         }
+        String attributeName = claim.getClaimType();
+        String attributeNamespace = claim.getClaimType();
+
+        if (StringUtils.isNotBlank(attributeNamespace) && attributeNamespace.contains("/") &&
+                attributeNamespace.length() > attributeNamespace.lastIndexOf("/") + 1) {
+            attributeName = attributeNamespace.substring(attributeNamespace.lastIndexOf("/") + 1);
+            attributeNamespace = attributeNamespace.substring(0, attributeNamespace.lastIndexOf("/"));
+        }
+        attributeBean.setSimpleName(attributeName);
+        attributeBean.setQualifiedName(attributeNamespace);
         attributeBean.setAttributeValues(claim.getValues());
 
         return attributeBean;
     }
-
 }


### PR DESCRIPTION
## Purpose

With the new implementation of Passive STS flow from IS 5.11 onwards, in the response the AttributeName is missing, only the AttributeNamespace is set. To fix this, the simpleName is set in the attribute name. Here for all local claims, the behaviour would be to split the claim uri across the attribute name and namespace. Custom claims will be split according to the nature of the claim, i.e. if it contains "/", split across name and namespace, otherwise the name and namespace will be the same.

## Related Issues
- Issue https://github.com/wso2-enterprise/wso2-iam-internal/issues/355
- Issue https://github.com/wso2/product-is/issues/15565