### PR TITLE
Add config for disabling AppliesTo element

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/pom.xml
@@ -109,6 +109,11 @@
             <artifactId>org.wso2.carbon.identity.testutil</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/processors/AttributeRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/processors/AttributeRequestProcessor.java
@@ -29,6 +29,8 @@ import org.apache.wss4j.common.WSS4JConstants;
 import org.apache.wss4j.common.principal.CustomTokenPrincipal;
 import org.w3c.dom.Element;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.sts.passive.RequestToken;
 import org.wso2.carbon.identity.sts.passive.ResponseToken;
 import org.wso2.carbon.identity.sts.passive.internal.IdentityPassiveSTSServiceComponent;
@@ -100,7 +102,10 @@ public class AttributeRequestProcessor extends RequestProcessor {
             issueTokenRequest.getAny().add(tokenType);
             Element secondaryParameters = createSecondaryParameters(request);
             issueTokenRequest.getAny().add(secondaryParameters);
-            issueTokenRequest.getAny().add(createAppliesToElement(request.getRealm()));
+            if (!Boolean.parseBoolean(IdentityUtil.getProperty(
+                    IdentityConstants.STS.PASSIVE_STS_DISABLE_APPLIES_TO_IN_RESPONSE))) {
+                issueTokenRequest.getAny().add(createAppliesToElement(request.getRealm()));
+            }
             Map<String, Object> msgCtx = setupMessageContext(request.getUserName());
 
             // Make an issue token request.

--- a/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/processors/SigningRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/processors/SigningRequestProcessor.java
@@ -29,7 +29,9 @@ import org.apache.wss4j.common.WSS4JConstants;
 import org.apache.wss4j.common.principal.CustomTokenPrincipal;
 import org.w3c.dom.Element;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.sts.passive.RequestToken;
 import org.wso2.carbon.identity.sts.passive.ResponseToken;
 import org.wso2.carbon.identity.sts.passive.internal.IdentityPassiveSTSServiceComponent;
@@ -101,7 +103,10 @@ public class SigningRequestProcessor extends RequestProcessor {
             issueTokenRequest.getAny().add(tokenType);
             Element secondaryParameters = createSecondaryParameters(request);
             issueTokenRequest.getAny().add(secondaryParameters);
-            issueTokenRequest.getAny().add(createAppliesToElement(request.getRealm()));
+            if (!Boolean.parseBoolean(IdentityUtil.getProperty(
+                    IdentityConstants.STS.PASSIVE_STS_DISABLE_APPLIES_TO_IN_RESPONSE))) {
+                issueTokenRequest.getAny().add(createAppliesToElement(request.getRealm()));
+            }
             Map<String, Object> msgCtx = setupMessageContext(request.getUserName());
 
             // Make an issue token request.

--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${h2database.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${apache.felix.scr.ds.annotations.version}</version>
@@ -444,7 +450,7 @@
     </build>
 
     <properties>
-        <identity.framework.version>5.20.66</identity.framework.version>
+        <identity.framework.version>5.25.131</identity.framework.version>
         <identity.inbound.auth.sts.package.export.version>${project.version}
         </identity.inbound.auth.sts.package.export.version>
         <inbound.auth.openid.version>5.6.0</inbound.auth.openid.version>
@@ -505,6 +511,7 @@
 
         <org.slf4j.verison>1.7.21</org.slf4j.verison>
         <testng.version>6.9.10</testng.version>
+        <h2database.version>2.1.210</h2database.version>
         <jacoco.version>0.7.9</jacoco.version>
         <powermock.version>1.7.0</powermock.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
     </build>
 
     <properties>
-        <identity.framework.version>5.25.131</identity.framework.version>
+        <identity.framework.version>5.25.132</identity.framework.version>
         <identity.inbound.auth.sts.package.export.version>${project.version}
         </identity.inbound.auth.sts.package.export.version>
         <inbound.auth.openid.version>5.6.0</inbound.auth.openid.version>


### PR DESCRIPTION
## Purpose

Since the .Net framework does not support the latest WS-Policy namespace `http://www.w3.org/ns/ws-policy`, those applications will break when the `AppliesTo` element exists in the Passive STS response. By default, this element is set in the response. Since this element can be optional, this PR introduces a config which can be used to disable the AppliesTo element in the response.
The following config can be used to disable it.
```
[passive_sts]
disable_applies_to_in_response = true
```

## Related PRs
- PR https://github.com/wso2/carbon-identity-framework/pull/4476

## Related Issues
- Issue https://github.com/wso2/product-is/issues/15592