### PR TITLE
Remove SHA1 default usage

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/utils/RequestProcessorUtil.java
+++ b/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/utils/RequestProcessorUtil.java
@@ -201,7 +201,16 @@ public class RequestProcessorUtil {
 
         String signatureAlgorithm = serverConfig.getFirstProperty(STS_SIGNATURE_ALGORITHM_KEY);
         String digestAlgorithm = serverConfig.getFirstProperty(STS_DIGEST_ALGORITHM_KEY);
-
+        boolean enableDefaultAlgorithms = Boolean.parseBoolean(IdentityUtil.getProperty(
+                IdentityConstants.STS.PASSIVE_STS_ENABLE_DEFAULT_SIGNATURE_AND_DIGEST_ALG));
+        if (enableDefaultAlgorithms) {
+            if (StringUtils.isBlank(signatureAlgorithm)) {
+                signatureAlgorithm = IdentityApplicationConstants.XML.SignatureAlgorithmURI.RSA_SHA256;
+            }
+            if (StringUtils.isBlank(digestAlgorithm)) {
+                digestAlgorithm = IdentityApplicationConstants.XML.DigestAlgorithmURI.SHA256;
+            }
+        }
 
         if (keyAlias == null) {
             throw new STSException("Private key alias cannot be null.");
@@ -223,19 +232,13 @@ public class RequestProcessorUtil {
         stsProperties.setSignatureUsername(keyAlias);
         stsProperties.setCallbackHandler(new PasswordCallbackHandler());
         stsProperties.setIssuer(getIssuerName());
-
         SignatureProperties signatureProperties = new SignatureProperties();
-        if (StringUtils.isNotBlank(signatureAlgorithm)) {
-            if (!signatureProperties.getAcceptedSignatureAlgorithms().contains(signatureAlgorithm)) {
-                signatureProperties.setAcceptedSignatureAlgorithms(
-                        Collections.singletonList(signatureAlgorithm));
-            }
-            signatureProperties.setSignatureAlgorithm(signatureAlgorithm);
+        if (!signatureProperties.getAcceptedSignatureAlgorithms().contains(signatureAlgorithm)) {
+            signatureProperties.setAcceptedSignatureAlgorithms(
+                    Collections.singletonList(signatureAlgorithm));
         }
-
-        if (StringUtils.isNotBlank(digestAlgorithm)) {
-            signatureProperties.setDigestAlgorithm(digestAlgorithm);
-        }
+        signatureProperties.setSignatureAlgorithm(signatureAlgorithm);
+        signatureProperties.setDigestAlgorithm(digestAlgorithm);
 
         stsProperties.setSignatureProperties(signatureProperties);
 

--- a/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/utils/RequestProcessorUtil.java
+++ b/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/utils/RequestProcessorUtil.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.carbon.identity.sts.passive.utils;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.helpers.DOMUtils;
@@ -224,12 +225,17 @@ public class RequestProcessorUtil {
         stsProperties.setIssuer(getIssuerName());
 
         SignatureProperties signatureProperties = new SignatureProperties();
-        if (!signatureProperties.getAcceptedSignatureAlgorithms().contains(signatureAlgorithm)) {
-            signatureProperties.setAcceptedSignatureAlgorithms(
-                    Collections.singletonList(signatureAlgorithm));
+        if (StringUtils.isNotBlank(signatureAlgorithm)) {
+            if (!signatureProperties.getAcceptedSignatureAlgorithms().contains(signatureAlgorithm)) {
+                signatureProperties.setAcceptedSignatureAlgorithms(
+                        Collections.singletonList(signatureAlgorithm));
+            }
+            signatureProperties.setSignatureAlgorithm(signatureAlgorithm);
         }
-        signatureProperties.setSignatureAlgorithm(signatureAlgorithm);
-        signatureProperties.setDigestAlgorithm(digestAlgorithm);
+
+        if (StringUtils.isNotBlank(digestAlgorithm)) {
+            signatureProperties.setDigestAlgorithm(digestAlgorithm);
+        }
 
         stsProperties.setSignatureProperties(signatureProperties);
 

--- a/components/org.wso2.carbon.mex/pom.xml
+++ b/components/org.wso2.carbon.mex/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.mex/src/main/java/org/wso2/carbon/mex/MexGetService.java
+++ b/components/org.wso2.carbon.mex/src/main/java/org/wso2/carbon/mex/MexGetService.java
@@ -24,6 +24,8 @@ import org.apache.axis2.context.MessageContext;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.mex.util.KeyUtil;
 
@@ -89,6 +91,22 @@ public class MexGetService {
 
                 if (log.isDebugEnabled()) {
                         log.debug("stsEndpointUrl:=> " + stsEndpointUrl);
+                }
+
+                String rsaSignatureAlgorithm;
+                if (StringUtils.isNotBlank(IdentityUtil.getProperty(
+                        IdentityConstants.MEX.MEX_DEFAULT_RSA_SIGNATURE_ALG))) {
+                        rsaSignatureAlgorithm =
+                                IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_RSA_SIGNATURE_ALG).trim();
+                } else {
+                        rsaSignatureAlgorithm = IdentityApplicationConstants.Mex.RSA_SHA256;
+                }
+                String hmacSignatureAlgorithm;
+                if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_HMAC_SIGNATURE_ALG))) {
+                        hmacSignatureAlgorithm =
+                                IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_HMAC_SIGNATURE_ALG).trim();
+                } else {
+                        hmacSignatureAlgorithm = IdentityApplicationConstants.Mex.HMAC_SHA256;
                 }
 
                 String response = "<Metadata xmlns=\"http://schemas.xmlsoap.org/ws/2004/09/mex\" xmlns:wsx=\"http://schemas.xmlsoap.org/ws/2004/09/mex\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
@@ -284,7 +302,7 @@ public class MexGetService {
                         "                                 <sp:RequestSecurityTokenTemplate>\n" +
                         "                                    <t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/PublicKey</t:KeyType>\n" +
                         "                                    <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</t:EncryptWith>\n" +
-                        "                                    <t:SignatureAlgorithm>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</t:SignatureAlgorithm>\n" +
+                        "                                    <t:SignatureAlgorithm>" + rsaSignatureAlgorithm + "</t:SignatureAlgorithm>\n" +
                         "                                    <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>\n" +
                         "                                    <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>\n" +
                         "                                 </sp:RequestSecurityTokenTemplate>\n" +
@@ -342,7 +360,7 @@ public class MexGetService {
                         "                                    <t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/SymmetricKey</t:KeyType>\n" +
                         "                                    <t:KeySize>256</t:KeySize>\n" +
                         "                                    <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptWith>\n" +
-                        "                                    <t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</t:SignatureAlgorithm>\n" +
+                        "                                    <t:SignatureAlgorithm>" + hmacSignatureAlgorithm + "</t:SignatureAlgorithm>\n" +
                         "                                    <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>\n" +
                         "                                    <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>\n" +
                         "                                 </sp:RequestSecurityTokenTemplate>\n" +
@@ -507,7 +525,7 @@ public class MexGetService {
                         "                                    <trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/PublicKey</trust:KeyType>\n" +
                         "                                    <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>\n" +
                         "                                    <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:EncryptWith>\n" +
-                        "                                    <trust:SignatureAlgorithm>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</trust:SignatureAlgorithm>\n" +
+                        "                                    <trust:SignatureAlgorithm>" + rsaSignatureAlgorithm + "</trust:SignatureAlgorithm>\n" +
                         "                                    <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>\n" +
                         "                                    <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>\n" +
                         "                                 </sp:RequestSecurityTokenTemplate>\n" +
@@ -566,7 +584,7 @@ public class MexGetService {
                         "                                    <trust:KeySize>256</trust:KeySize>\n" +
                         "                                    <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>\n" +
                         "                                    <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptWith>\n" +
-                        "                                    <trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</trust:SignatureAlgorithm>\n" +
+                        "                                    <trust:SignatureAlgorithm>" + hmacSignatureAlgorithm + "</trust:SignatureAlgorithm>\n" +
                         "                                    <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>\n" +
                         "                                    <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>\n" +
                         "                                 </sp:RequestSecurityTokenTemplate>\n" +

--- a/components/org.wso2.carbon.mex/src/main/java/org/wso2/carbon/mex/MexGetService.java
+++ b/components/org.wso2.carbon.mex/src/main/java/org/wso2/carbon/mex/MexGetService.java
@@ -94,19 +94,13 @@ public class MexGetService {
                 }
 
                 String rsaSignatureAlgorithm;
-                if (StringUtils.isNotBlank(IdentityUtil.getProperty(
-                        IdentityConstants.MEX.MEX_DEFAULT_RSA_SIGNATURE_ALG))) {
-                        rsaSignatureAlgorithm =
-                                IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_RSA_SIGNATURE_ALG).trim();
-                } else {
-                        rsaSignatureAlgorithm = IdentityApplicationConstants.Mex.RSA_SHA256;
-                }
                 String hmacSignatureAlgorithm;
-                if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_HMAC_SIGNATURE_ALG))) {
-                        hmacSignatureAlgorithm =
-                                IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_HMAC_SIGNATURE_ALG).trim();
-                } else {
+                if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.MEX.ENABLE_SHA256_SIGNATURE_ALG))) {
+                        rsaSignatureAlgorithm = IdentityApplicationConstants.Mex.RSA_SHA256;
                         hmacSignatureAlgorithm = IdentityApplicationConstants.Mex.HMAC_SHA256;
+                } else {
+                        rsaSignatureAlgorithm = IdentityApplicationConstants.Mex.RSA_SHA1;
+                        hmacSignatureAlgorithm = IdentityApplicationConstants.Mex.HMAC_SHA1;
                 }
 
                 String response = "<Metadata xmlns=\"http://schemas.xmlsoap.org/ws/2004/09/mex\" xmlns:wsx=\"http://schemas.xmlsoap.org/ws/2004/09/mex\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +

--- a/components/org.wso2.carbon.mex/src/main/java/org/wso2/carbon/mex/MexGetService.java
+++ b/components/org.wso2.carbon.mex/src/main/java/org/wso2/carbon/mex/MexGetService.java
@@ -284,7 +284,7 @@ public class MexGetService {
                         "                                 <sp:RequestSecurityTokenTemplate>\n" +
                         "                                    <t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/PublicKey</t:KeyType>\n" +
                         "                                    <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</t:EncryptWith>\n" +
-                        "                                    <t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</t:SignatureAlgorithm>\n" +
+                        "                                    <t:SignatureAlgorithm>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</t:SignatureAlgorithm>\n" +
                         "                                    <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>\n" +
                         "                                    <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>\n" +
                         "                                 </sp:RequestSecurityTokenTemplate>\n" +
@@ -507,7 +507,7 @@ public class MexGetService {
                         "                                    <trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/PublicKey</trust:KeyType>\n" +
                         "                                    <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>\n" +
                         "                                    <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:EncryptWith>\n" +
-                        "                                    <trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</trust:SignatureAlgorithm>\n" +
+                        "                                    <trust:SignatureAlgorithm>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</trust:SignatureAlgorithm>\n" +
                         "                                    <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>\n" +
                         "                                    <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>\n" +
                         "                                 </sp:RequestSecurityTokenTemplate>\n" +

--- a/components/org.wso2.carbon.mex2/pom.xml
+++ b/components/org.wso2.carbon.mex2/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.mex2/src/main/java/org/wso2/carbon/mex2/MexGetService.java
+++ b/components/org.wso2.carbon.mex2/src/main/java/org/wso2/carbon/mex2/MexGetService.java
@@ -431,7 +431,7 @@ public class MexGetService {
                         "                           <sp:RequestSecurityTokenTemplate>\n" +
                         "                              <t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/PublicKey</t:KeyType>\n" +
                         "                              <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</t:EncryptWith>\n" +
-                        "                              <t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</t:SignatureAlgorithm>\n" +
+                        "                              <t:SignatureAlgorithm>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</t:SignatureAlgorithm>\n" +
                         "                              <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>\n" +
                         "                              <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>\n" +
                         "                           </sp:RequestSecurityTokenTemplate>\n" +
@@ -704,7 +704,7 @@ public class MexGetService {
                         "                              <trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/PublicKey</trust:KeyType>\n" +
                         "                              <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>\n" +
                         "                              <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:EncryptWith>\n" +
-                        "                              <trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</trust:SignatureAlgorithm>\n" +
+                        "                              <trust:SignatureAlgorithm>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</trust:SignatureAlgorithm>\n" +
                         "                              <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>\n" +
                         "                              <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>\n" +
                         "                           </sp:RequestSecurityTokenTemplate>\n" +
@@ -1503,7 +1503,7 @@ public class MexGetService {
                         "                     <sp:RequestSecurityTokenTemplate>\n" +
                         "                        <t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/PublicKey</t:KeyType>\n" +
                         "                        <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</t:EncryptWith>\n" +
-                        "                        <t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</t:SignatureAlgorithm>\n" +
+                        "                        <t:SignatureAlgorithm>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</t:SignatureAlgorithm>\n" +
                         "                        <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>\n" +
                         "                        <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>\n" +
                         "                     </sp:RequestSecurityTokenTemplate>\n" +
@@ -1776,7 +1776,7 @@ public class MexGetService {
                         "                        <trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/PublicKey</trust:KeyType>\n" +
                         "                        <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>\n" +
                         "                        <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:EncryptWith>\n" +
-                        "                        <trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</trust:SignatureAlgorithm>\n" +
+                        "                        <trust:SignatureAlgorithm>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</trust:SignatureAlgorithm>\n" +
                         "                        <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>\n" +
                         "                        <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>\n" +
                         "                     </sp:RequestSecurityTokenTemplate>\n" +

--- a/components/org.wso2.carbon.mex2/src/main/java/org/wso2/carbon/mex2/MexGetService.java
+++ b/components/org.wso2.carbon.mex2/src/main/java/org/wso2/carbon/mex2/MexGetService.java
@@ -92,18 +92,13 @@ public class MexGetService {
                 }
 
                 String rsaSignatureAlgorithm;
-                if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_RSA_SIGNATURE_ALG))) {
-                        rsaSignatureAlgorithm =
-                                IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_RSA_SIGNATURE_ALG).trim();
-                } else {
-                        rsaSignatureAlgorithm = IdentityApplicationConstants.Mex.RSA_SHA256;
-                }
                 String hmacSignatureAlgorithm;
-                if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_HMAC_SIGNATURE_ALG))) {
-                        hmacSignatureAlgorithm =
-                                IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_HMAC_SIGNATURE_ALG).trim();
-                } else {
+                if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.MEX.ENABLE_SHA256_SIGNATURE_ALG))) {
+                        rsaSignatureAlgorithm = IdentityApplicationConstants.Mex.RSA_SHA256;
                         hmacSignatureAlgorithm = IdentityApplicationConstants.Mex.HMAC_SHA256;
+                } else {
+                        rsaSignatureAlgorithm = IdentityApplicationConstants.Mex.RSA_SHA1;
+                        hmacSignatureAlgorithm = IdentityApplicationConstants.Mex.HMAC_SHA1;
                 }
 
                 String response = "<Metadata xmlns=\"http://schemas.xmlsoap.org/ws/2004/09/mex\" xmlns:wsx=\"http://schemas.xmlsoap.org/ws/2004/09/mex\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
@@ -1181,18 +1176,13 @@ public class MexGetService {
                 }
 
                 String rsaSignatureAlgorithm;
-                if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_RSA_SIGNATURE_ALG))) {
-                        rsaSignatureAlgorithm =
-                                IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_RSA_SIGNATURE_ALG).trim();
-                } else {
-                        rsaSignatureAlgorithm = IdentityApplicationConstants.Mex.RSA_SHA256;
-                }
                 String hmacSignatureAlgorithm;
-                if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_HMAC_SIGNATURE_ALG))) {
-                        hmacSignatureAlgorithm =
-                                IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_HMAC_SIGNATURE_ALG).trim();
-                } else {
+                if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.MEX.ENABLE_SHA256_SIGNATURE_ALG))) {
+                        rsaSignatureAlgorithm = IdentityApplicationConstants.Mex.RSA_SHA256;
                         hmacSignatureAlgorithm = IdentityApplicationConstants.Mex.HMAC_SHA256;
+                } else {
+                        rsaSignatureAlgorithm = IdentityApplicationConstants.Mex.RSA_SHA1;
+                        hmacSignatureAlgorithm = IdentityApplicationConstants.Mex.HMAC_SHA1;
                 }
 
                 String response = "<wsdl:definitions xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\" xmlns:msc=\"http://schemas.microsoft.com/ws/2005/12/wsdl/contract\" xmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\" xmlns:soap12=\"http://schemas.xmlsoap.org/wsdl/soap12/\" xmlns:soapenc=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:t=\"http://schemas.xmlsoap.org/ws/2005/02/trust\" xmlns:tns=\"http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice\" xmlns:trust=\"http://docs.oasis-open.org/ws-sx/ws-trust/200512\" xmlns:wsa=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\" xmlns:wsa10=\"http://www.w3.org/2005/08/addressing\" xmlns:wsam=\"http://www.w3.org/2007/05/addressing/metadata\" xmlns:wsap=\"http://schemas.xmlsoap.org/ws/2004/08/addressing/policy\" xmlns:wsaw=\"http://www.w3.org/2006/05/addressing/wsdl\" xmlns:wsp=\"http://schemas.xmlsoap.org/ws/2004/09/policy\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" xmlns:wsx=\"http://schemas.xmlsoap.org/ws/2004/09/mex\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" name=\"SecurityTokenService\" targetNamespace=\"http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice\">\n" +

--- a/components/org.wso2.carbon.mex2/src/main/java/org/wso2/carbon/mex2/MexGetService.java
+++ b/components/org.wso2.carbon.mex2/src/main/java/org/wso2/carbon/mex2/MexGetService.java
@@ -26,6 +26,8 @@ import org.apache.axis2.context.MessageContext;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.mex2.util.KeyUtil;
 import java.security.cert.X509Certificate;
@@ -87,6 +89,21 @@ public class MexGetService {
                 if (log.isDebugEnabled()) {
                         log.debug("stsEndpointUrl:=> " + stsEndpointUrl + "mexEndpointUrl:=> " + kerbosEndpointUrl);
 
+                }
+
+                String rsaSignatureAlgorithm;
+                if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_RSA_SIGNATURE_ALG))) {
+                        rsaSignatureAlgorithm =
+                                IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_RSA_SIGNATURE_ALG).trim();
+                } else {
+                        rsaSignatureAlgorithm = IdentityApplicationConstants.Mex.RSA_SHA256;
+                }
+                String hmacSignatureAlgorithm;
+                if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_HMAC_SIGNATURE_ALG))) {
+                        hmacSignatureAlgorithm =
+                                IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_HMAC_SIGNATURE_ALG).trim();
+                } else {
+                        hmacSignatureAlgorithm = IdentityApplicationConstants.Mex.HMAC_SHA256;
                 }
 
                 String response = "<Metadata xmlns=\"http://schemas.xmlsoap.org/ws/2004/09/mex\" xmlns:wsx=\"http://schemas.xmlsoap.org/ws/2004/09/mex\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
@@ -431,7 +448,7 @@ public class MexGetService {
                         "                           <sp:RequestSecurityTokenTemplate>\n" +
                         "                              <t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/PublicKey</t:KeyType>\n" +
                         "                              <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</t:EncryptWith>\n" +
-                        "                              <t:SignatureAlgorithm>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</t:SignatureAlgorithm>\n" +
+                        "                              <t:SignatureAlgorithm>" + rsaSignatureAlgorithm + "</t:SignatureAlgorithm>\n" +
                         "                              <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>\n" +
                         "                              <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>\n" +
                         "                           </sp:RequestSecurityTokenTemplate>\n" +
@@ -489,7 +506,7 @@ public class MexGetService {
                         "                              <t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/SymmetricKey</t:KeyType>\n" +
                         "                              <t:KeySize>256</t:KeySize>\n" +
                         "                              <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptWith>\n" +
-                        "                              <t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</t:SignatureAlgorithm>\n" +
+                        "                              <t:SignatureAlgorithm>" + hmacSignatureAlgorithm + "</t:SignatureAlgorithm>\n" +
                         "                              <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>\n" +
                         "                              <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>\n" +
                         "                           </sp:RequestSecurityTokenTemplate>\n" +
@@ -704,7 +721,7 @@ public class MexGetService {
                         "                              <trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/PublicKey</trust:KeyType>\n" +
                         "                              <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>\n" +
                         "                              <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:EncryptWith>\n" +
-                        "                              <trust:SignatureAlgorithm>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</trust:SignatureAlgorithm>\n" +
+                        "                              <trust:SignatureAlgorithm>" + rsaSignatureAlgorithm + "</trust:SignatureAlgorithm>\n" +
                         "                              <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>\n" +
                         "                              <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>\n" +
                         "                           </sp:RequestSecurityTokenTemplate>\n" +
@@ -763,7 +780,7 @@ public class MexGetService {
                         "                              <trust:KeySize>256</trust:KeySize>\n" +
                         "                              <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>\n" +
                         "                              <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptWith>\n" +
-                        "                              <trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</trust:SignatureAlgorithm>\n" +
+                        "                              <trust:SignatureAlgorithm>" + hmacSignatureAlgorithm + "</trust:SignatureAlgorithm>\n" +
                         "                              <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>\n" +
                         "                              <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>\n" +
                         "                           </sp:RequestSecurityTokenTemplate>\n" +
@@ -1163,6 +1180,21 @@ public class MexGetService {
 
                 }
 
+                String rsaSignatureAlgorithm;
+                if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_RSA_SIGNATURE_ALG))) {
+                        rsaSignatureAlgorithm =
+                                IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_RSA_SIGNATURE_ALG).trim();
+                } else {
+                        rsaSignatureAlgorithm = IdentityApplicationConstants.Mex.RSA_SHA256;
+                }
+                String hmacSignatureAlgorithm;
+                if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_HMAC_SIGNATURE_ALG))) {
+                        hmacSignatureAlgorithm =
+                                IdentityUtil.getProperty(IdentityConstants.MEX.MEX_DEFAULT_HMAC_SIGNATURE_ALG).trim();
+                } else {
+                        hmacSignatureAlgorithm = IdentityApplicationConstants.Mex.HMAC_SHA256;
+                }
+
                 String response = "<wsdl:definitions xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\" xmlns:msc=\"http://schemas.microsoft.com/ws/2005/12/wsdl/contract\" xmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\" xmlns:soap12=\"http://schemas.xmlsoap.org/wsdl/soap12/\" xmlns:soapenc=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:t=\"http://schemas.xmlsoap.org/ws/2005/02/trust\" xmlns:tns=\"http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice\" xmlns:trust=\"http://docs.oasis-open.org/ws-sx/ws-trust/200512\" xmlns:wsa=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\" xmlns:wsa10=\"http://www.w3.org/2005/08/addressing\" xmlns:wsam=\"http://www.w3.org/2007/05/addressing/metadata\" xmlns:wsap=\"http://schemas.xmlsoap.org/ws/2004/08/addressing/policy\" xmlns:wsaw=\"http://www.w3.org/2006/05/addressing/wsdl\" xmlns:wsp=\"http://schemas.xmlsoap.org/ws/2004/09/policy\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" xmlns:wsx=\"http://schemas.xmlsoap.org/ws/2004/09/mex\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" name=\"SecurityTokenService\" targetNamespace=\"http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice\">\n" +
                         "   <wsp:Policy wsu:Id=\"CustomBinding_IWSTrustFeb2005Async_policy\">\n" +
                         "      <wsp:ExactlyOne>\n" +
@@ -1503,7 +1535,7 @@ public class MexGetService {
                         "                     <sp:RequestSecurityTokenTemplate>\n" +
                         "                        <t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/PublicKey</t:KeyType>\n" +
                         "                        <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</t:EncryptWith>\n" +
-                        "                        <t:SignatureAlgorithm>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</t:SignatureAlgorithm>\n" +
+                        "                        <t:SignatureAlgorithm>" + rsaSignatureAlgorithm + "</t:SignatureAlgorithm>\n" +
                         "                        <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>\n" +
                         "                        <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>\n" +
                         "                     </sp:RequestSecurityTokenTemplate>\n" +
@@ -1561,7 +1593,7 @@ public class MexGetService {
                         "                        <t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/SymmetricKey</t:KeyType>\n" +
                         "                        <t:KeySize>256</t:KeySize>\n" +
                         "                        <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptWith>\n" +
-                        "                        <t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</t:SignatureAlgorithm>\n" +
+                        "                        <t:SignatureAlgorithm>" + hmacSignatureAlgorithm + "</t:SignatureAlgorithm>\n" +
                         "                        <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>\n" +
                         "                        <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>\n" +
                         "                     </sp:RequestSecurityTokenTemplate>\n" +
@@ -1776,7 +1808,7 @@ public class MexGetService {
                         "                        <trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/PublicKey</trust:KeyType>\n" +
                         "                        <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>\n" +
                         "                        <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:EncryptWith>\n" +
-                        "                        <trust:SignatureAlgorithm>http://www.w3.org/2001/04/xmldsig-more#rsa-sha256</trust:SignatureAlgorithm>\n" +
+                        "                        <trust:SignatureAlgorithm>" + rsaSignatureAlgorithm + "</trust:SignatureAlgorithm>\n" +
                         "                        <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>\n" +
                         "                        <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>\n" +
                         "                     </sp:RequestSecurityTokenTemplate>\n" +
@@ -1835,7 +1867,7 @@ public class MexGetService {
                         "                        <trust:KeySize>256</trust:KeySize>\n" +
                         "                        <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>\n" +
                         "                        <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptWith>\n" +
-                        "                        <trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</trust:SignatureAlgorithm>\n" +
+                        "                        <trust:SignatureAlgorithm>" + hmacSignatureAlgorithm + "</trust:SignatureAlgorithm>\n" +
                         "                        <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>\n" +
                         "                        <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>\n" +
                         "                     </sp:RequestSecurityTokenTemplate>\n" +

--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
     </build>
 
     <properties>
-        <identity.framework.version>5.25.132</identity.framework.version>
+        <identity.framework.version>5.25.164</identity.framework.version>
         <identity.inbound.auth.sts.package.export.version>${project.version}
         </identity.inbound.auth.sts.package.export.version>
         <inbound.auth.openid.version>5.6.0</inbound.auth.openid.version>

--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
     </build>
 
     <properties>
-        <identity.framework.version>5.25.164</identity.framework.version>
+        <identity.framework.version>5.25.210</identity.framework.version>
         <identity.inbound.auth.sts.package.export.version>${project.version}
         </identity.inbound.auth.sts.package.export.version>
         <inbound.auth.openid.version>5.6.0</inbound.auth.openid.version>


### PR DESCRIPTION
## Purpose

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the SHA1 usages of the following flows to SHA256.

- Default response signing method and response digest method in Passive STS response.
- Default signature algorithms used in MexGetService (mexut) 

### Migration impact
The default signing and digest algorithms of Passive STS response would change for all existing apps. The following config can be used to revert enabling the default SHA256 signing and digest algorithms in Passive STS response.
```
[passive_sts]
enable_default_signature_and_digest_alg= false
```

The default signature algorithms of MexGetService changes. The following config can be used to revert enabling the default SHA256 signing and digest algorithms in Passive STS 
```
[mex]
enable_sha256_alg= false
```

## Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

## Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/162
- PR https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/136
- PR https://github.com/wso2-extensions/identity-metadata-saml2/pull/85
- PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076
- PR https://github.com/wso2/cipher-tool/pull/78
- PR https://github.com/wso2/carbon-kernel/pull/3574
- PR https://github.com/wso2-extensions/identity-user-account-association/pull/47
- PR https://github.com/wso2-enterprise/asgardeo-website/pull/639
- PR https://github.com/wso2-extensions/identity-governance/pull/707
- PR https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/92
- PR https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/173
- PR https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/157

## Documentation

- PR https://github.com/wso2/docs-is/pull/3717