### PR TITLE
Migrate security-mgt module from framework to its own group.

### DIFF
--- a/components/org.wso2.carbon.identity.sts.mgt/pom.xml
+++ b/components/org.wso2.carbon.identity.sts.mgt/pom.xml
@@ -66,7 +66,7 @@
             <artifactId>rampart-trust</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <groupId>org.wso2.carbon.security.mgt</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
         </dependency>
         <dependency>
@@ -137,7 +137,7 @@
 
                             org.wso2.carbon.identity.base; version="${identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.*; version="${identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.security.*; version="${identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.security.*; version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.sts.common.*; version="${identity.inbound.auth.sts.imp.pkg.version.range}"
                             org.wso2.carbon.identity.provider;
                             version="${identity.inbound.auth.openid.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.sts.passive/pom.xml
+++ b/components/org.wso2.carbon.identity.sts.passive/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <groupId>org.wso2.carbon.security.mgt</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
         </dependency>
         <dependency>
@@ -200,11 +200,11 @@
                             org.wso2.carbon.identity.application.mgt;
                             version="${identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.security.keystore.*;
-                            version="${identity.framework.imp.pkg.version.range}",
+                            version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.security.util;
-                            version="${identity.framework.imp.pkg.version.range}",
+                            version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.security.sts.service;
-                            version="${identity.framework.imp.pkg.version.range}",
+                            version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.*;
                             version="${identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*;

--- a/components/org.wso2.carbon.mex/pom.xml
+++ b/components/org.wso2.carbon.mex/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>axis2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <groupId>org.wso2.carbon.security.mgt</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
         </dependency>
         <dependency>
@@ -108,14 +108,14 @@
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",
                             org.wso2.carbon.registry.api;version="${carbon.kernel.registry.imp.pkg.version}",
 
-                            org.wso2.carbon.security.util; version="${identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.security.util; version="${carbon.security.keystore.service.version.range}",
                             org.wso2.carbon.security.keystore.*;
-                            version="${identity.framework.imp.pkg.version.range}",
+                            version="${carbon.security.keystore.service.version.range}",
                             org.apache.neethi; version="${neethi.osgi.version.range}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
-                            org.wso2.carbon.security.*;version="${identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.security.*;version="${carbon.security.keystore.service.version.range}",
                             javax.cache,
-                            org.wso2.carbon.security.*;version="${identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.security.*;version="${carbon.security.keystore.service.version.range}",
                             org.wso2.xfer.*; version="${xfer.import.pkg.version}",
                             org.wso2.carbon.identity.core.util; version="${identity.framework.imp.pkg.version.range}",
                         </Import-Package>

--- a/components/org.wso2.carbon.mex/pom.xml
+++ b/components/org.wso2.carbon.mex/pom.xml
@@ -108,14 +108,14 @@
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",
                             org.wso2.carbon.registry.api;version="${carbon.kernel.registry.imp.pkg.version}",
 
-                            org.wso2.carbon.security.util; version="${carbon.security.keystore.service.version.range}",
+                            org.wso2.carbon.security.util; version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.security.keystore.*;
-                            version="${carbon.security.keystore.service.version.range}",
+                            version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.apache.neethi; version="${neethi.osgi.version.range}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
-                            org.wso2.carbon.security.*;version="${carbon.security.keystore.service.version.range}",
+                            org.wso2.carbon.security.*;version="${carbon.security.mgt.imp.pkg.version.range}",
                             javax.cache,
-                            org.wso2.carbon.security.*;version="${carbon.security.keystore.service.version.range}",
+                            org.wso2.carbon.security.*;version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.wso2.xfer.*; version="${xfer.import.pkg.version}",
                             org.wso2.carbon.identity.core.util; version="${identity.framework.imp.pkg.version.range}",
                         </Import-Package>

--- a/components/org.wso2.carbon.mex2/pom.xml
+++ b/components/org.wso2.carbon.mex2/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>axis2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <groupId>org.wso2.carbon.security.mgt</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
         </dependency>
         <dependency>
@@ -108,14 +108,14 @@
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",
                             org.wso2.carbon.registry.api;version="${carbon.kernel.registry.imp.pkg.version}",
 
-                            org.wso2.carbon.security.util; version="${identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.security.util; version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.security.keystore.*;
-                            version="${identity.framework.imp.pkg.version.range}",
+                            version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.apache.neethi; version="${neethi.osgi.version.range}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
-                            org.wso2.carbon.security.*;version="${identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.security.*;version="${carbon.security.mgt.imp.pkg.version.range}",
                             javax.cache,
-                            org.wso2.carbon.security.*;version="${identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.security.*;version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.wso2.xfer.*; version="${xfer.import.pkg.version}",
                             org.wso2.carbon.identity.core.util; version="${identity.framework.imp.pkg.version.range}",
                         </Import-Package>

--- a/components/org.wso2.carbon.security.sts.common/pom.xml
+++ b/components/org.wso2.carbon.security.sts.common/pom.xml
@@ -135,7 +135,7 @@
             <artifactId>org.wso2.carbon.identity.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <groupId>org.wso2.carbon.security.mgt</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
         </dependency>
     </dependencies>
@@ -199,7 +199,7 @@
                             org.wso2.carbon.identity.base; version="${identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.*;
                             version="${identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.security.*; version="${identity.framework.imp.pkg.version.range}"
+                            org.wso2.carbon.security.*; version="${carbon.security.mgt.imp.pkg.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.sts.common.internal,

--- a/components/org.wso2.carbon.sts/pom.xml
+++ b/components/org.wso2.carbon.sts/pom.xml
@@ -60,7 +60,7 @@
             <artifactId>org.wso2.carbon.identity.application.common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <groupId>org.wso2.carbon.security.mgt</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
         </dependency>
         <dependency>
@@ -133,12 +133,12 @@
                             org.wso2.carbon.identity.application.common.*; version="${identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.mgt.*; version="${identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.*; version="${identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.security.util; version="${identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.security.util; version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.security.keystore.*;
-                            version="${identity.framework.imp.pkg.version.range}",
+                            version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.apache.neethi; version="${neethi.osgi.version.range}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
-                            org.wso2.carbon.security.*; version="${identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.security.*; version="${carbon.security.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.sts.common.*; version="${identity.inbound.auth.sts.imp.pkg.version.range}",
                             org.wso2.carbon.identity.sts.store;
                             version="${identity.inbound.auth.sts.imp.pkg.version.range}",

--- a/features/org.wso2.carbon.identity.sts.mgt.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.sts.mgt.server.feature/pom.xml
@@ -68,7 +68,7 @@
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.feature.version}</importFeatureDef>
-                                <importFeatureDef>org.wso2.carbon.security.mgt.server:compatible:${identity.framework.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.security.mgt.server:compatible:${carbon.security.mgt.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.core.server:compatible:${identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.provider.server:compatible:${inbound.auth.openid.version}</importFeatureDef>
                             </importFeatures>

--- a/features/org.wso2.carbon.identity.sts.passive.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.sts.passive.server.feature/pom.xml
@@ -95,7 +95,7 @@
                                 <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.feature.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.authentication.framework.server:compatible:${identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.mgt.server:compatible:${identity.framework.version}</importFeatureDef>
-                                <importFeatureDef>org.wso2.carbon.security.mgt.server:compatible:${identity.framework.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.security.mgt.server:compatible:${carbon.security.mgt.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.provider.server:compatible:${inbound.auth.openid.version}</importFeatureDef>
                             </importFeatures>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -185,9 +185,9 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <groupId>org.wso2.carbon.security.mgt</groupId>
                 <artifactId>org.wso2.carbon.security.mgt</artifactId>
-                <version>${identity.framework.version}</version>
+                <version>${carbon.security.mgt.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.axis2.wso2</groupId>
@@ -454,6 +454,8 @@
         <identity.inbound.auth.sts.package.export.version>${project.version}
         </identity.inbound.auth.sts.package.export.version>
         <inbound.auth.openid.version>5.6.0</inbound.auth.openid.version>
+        <carbon.security.mgt.version>1.0.0</carbon.security.mgt.version>
+        <carbon.security.mgt.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.security.mgt.imp.pkg.version.range>
 
         <carbon.kernel.version>4.7.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.7.0</carbon.kernel.feature.version>


### PR DESCRIPTION
### Proposed changes in this pull request
This PR contains the changes made to migrate the security-mgt component from framework and move it to new carbon.security.mgt group. This is a milestone of the following issue[1].

### Related Issues
- https://github.com/wso2/product-is/issues/16422

### NOTE:
- Product IS PR builder will fail because the the security-mgt component used there is still old version. 
