### PR TITLE
Improve tenant resolving with tenant qualified URL enabled.

### DIFF
--- a/components/org.wso2.carbon.identity.sts.mgt.ui/src/main/resources/web/generic-sts/sts.jsp
+++ b/components/org.wso2.carbon.identity.sts.mgt.ui/src/main/resources/web/generic-sts/sts.jsp
@@ -112,7 +112,7 @@
     try {
         String tenantDomain;
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+            tenantDomain = IdentityTenantUtil.resolveTenantDomain();
         } else {
     	    tenantDomain = (String) session.getAttribute(MultitenantConstants.TENANT_DOMAIN);
         }

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
@@ -531,7 +531,7 @@ public class PassiveSTS extends HttpServlet {
         String wtrealm = getAttribute(request.getParameterMap(), PassiveRequestorConstants.REALM);
         String tenantDomain;
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+            tenantDomain = IdentityTenantUtil.resolveTenantDomain();
         } else {
             tenantDomain = getAttribute(request.getParameterMap(), MultitenantConstants.TENANT_DOMAIN);
         }
@@ -643,7 +643,7 @@ public class PassiveSTS extends HttpServlet {
 
         String tenantDomain;
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+            tenantDomain = IdentityTenantUtil.resolveTenantDomain();
             if (log.isDebugEnabled()) {
                 log.debug("Tenant domain from context: " + tenantDomain);
             }

--- a/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/PassiveSTSService.java
+++ b/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/PassiveSTSService.java
@@ -215,7 +215,7 @@ public class PassiveSTSService {
         try {
             String tenantDomain;
             if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-                tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+                tenantDomain = IdentityTenantUtil.resolveTenantDomain();
             } else {
                 tenantDomain = request.getTenantDomain();
             }

--- a/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/processors/SigningRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/processors/SigningRequestProcessor.java
@@ -66,7 +66,7 @@ public class SigningRequestProcessor extends RequestProcessor {
 
         try {
             if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-                tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+                tenantDomain = IdentityTenantUtil.resolveTenantDomain();
             } else {
                 tenantDomain = request.getTenantDomain();
             }

--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
     </build>
 
     <properties>
-        <identity.framework.version>5.25.305</identity.framework.version>
+        <identity.framework.version>5.25.380</identity.framework.version>
         <identity.inbound.auth.sts.package.export.version>${project.version}
         </identity.inbound.auth.sts.package.export.version>
         <inbound.auth.openid.version>5.6.0</inbound.auth.openid.version>


### PR DESCRIPTION
Related issue:
- https://github.com/wso2/product-is/issues/16906

Improve resolving tenant domain when tenant qualified URL feature is enabled. If the tenant domain is available in the context retrieve it otherwise retrieve tenant domain from the privileged carbon context.