### PR TITLE
Add validation for logout wreply url

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/pom.xml
@@ -136,6 +136,7 @@
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
                             org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
+                            org.apache.http.client.utils; version="${httpcomponents-httpclient.imp.pkg.version.range}",
                             org.wso2.carbon.ui; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.registry.core.utils; version="${carbon.kernel.registry.imp.pkg.version}",
                             org.wso2.carbon.identity.application.authentication.framework.*;

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveRequestorConstants.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveRequestorConstants.java
@@ -65,6 +65,11 @@ public class PassiveRequestorConstants {
 
     public static final String RELYING_PARTY_REALMS = "realms";
 
+    public static final String ERROR_AUTHENTICATION = "Authentication Error!";
+
+    public static final String ERROR_MSG_LOGOUT_WREPLY_MISMATCH = "Error in validating the application's logout " +
+            "redirect URL against the configured redirect URL.";
+
     private PassiveRequestorConstants() {
     }
 }

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveRequestorConstants.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveRequestorConstants.java
@@ -68,7 +68,7 @@ public class PassiveRequestorConstants {
     public static final String ERROR_AUTHENTICATION = "Authentication Error!";
 
     public static final String ERROR_MSG_LOGOUT_WREPLY_MISMATCH = "Error in validating the application's logout " +
-            "redirect URL against the configured redirect URL.";
+            "redirect URL against the configured WReply Logout URL.";
 
     private PassiveRequestorConstants() {
     }

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
@@ -549,7 +549,7 @@ public class PassiveSTS extends HttpServlet {
 
         String wreplyFromReq = getAttribute(request.getParameterMap(), PassiveRequestorConstants.REPLY_TO);
         if (StringUtils.isNotBlank(wreplyFromReq)) {
-            String configuredWreply = getConfiguredWreplyUrl(request);
+            String configuredWreply = getConfiguredWreplyLogoutUrl(request);
             if (!wreplyFromReq.equals(configuredWreply)) {
                 throw new PassiveSTSException("Provided wreply URL in the request does not match the configured " +
                         "wreply logout url.");
@@ -558,13 +558,13 @@ public class PassiveSTS extends HttpServlet {
     }
 
     /**
-     * Retrieve the configured wreply url from the service provider.
+     * Retrieve the configured wreply logout url from the service provider.
      *
      * @param request   Logout request.
-     * @return          Wreply url configured in the service provider.
+     * @return          Wreply logout url configured in the service provider.
      * @throws PassiveSTSException Errors in retrieving the configured wreply url.
      */
-    private String getConfiguredWreplyUrl(HttpServletRequest request) throws PassiveSTSException {
+    private String getConfiguredWreplyLogoutUrl(HttpServletRequest request) throws PassiveSTSException {
 
         String wtrealm = getAttribute(request.getParameterMap(), PassiveRequestorConstants.REALM);
         if (StringUtils.isBlank(wtrealm)) {

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
@@ -87,6 +87,8 @@ import java.util.Scanner;
 import java.util.Set;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUTHENTICATED_USER;
+import static org.wso2.carbon.identity.sts.passive.ui.PassiveRequestorConstants.ERROR_AUTHENTICATION;
+import static org.wso2.carbon.identity.sts.passive.ui.PassiveRequestorConstants.ERROR_MSG_LOGOUT_WREPLY_MISMATCH;
 
 public class PassiveSTS extends HttpServlet {
 
@@ -108,6 +110,7 @@ public class PassiveSTS extends HttpServlet {
     private static final String HTTPS = "https";
     private static final String PASSIVE_STS_CLIENT_TYPE = "passivests";
     private static final String PASSIVE_STS_W_REPLY_PROPERTY = "passiveSTSWReply";
+    private static final String PASSIVE_STS_W_REPLY_LOGOUT_PROPERTY = "passiveSTSWReplyLogout";
     private static final String PASSIVE_STS_EP_URL = "/passivests";
 
     /**
@@ -498,6 +501,19 @@ public class PassiveSTS extends HttpServlet {
     private void handleLogoutRequest(HttpServletRequest request, HttpServletResponse response)
             throws IOException, PassiveSTSException {
 
+        // Validate the logout url if the logout wreply validation is enabled.
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(
+                IdentityConstants.STS.PASSIVE_STS_LOGOUT_WREPLY_VALIDATION))) {
+            try {
+                validateLogoutURL(request);
+            } catch (PassiveSTSException e) {
+                log.error(e.getMessage());
+                PassiveSTSUtil.sendToErrorPage(request, response,
+                        ERROR_AUTHENTICATION, ERROR_MSG_LOGOUT_WREPLY_MISMATCH);
+                return;
+            }
+        }
+
         // wreply parameter is optional for the logout request. So we are setting that value from the service
         // provider configuration in case it is not available in the request.
         if (StringUtils.isBlank(getAttribute(request.getParameterMap(), PassiveRequestorConstants.REPLY_TO)) &&
@@ -519,6 +535,123 @@ public class PassiveSTS extends HttpServlet {
                 log.debug("Error while sending the logout request", e);
             }
         }
+    }
+
+    /**
+     * Validate the wreply url sent in the logout request with the configured logout wreply url.
+     * The user is redirected to an error page upon validation failure.
+     *
+     * @param request   Logout request.
+     * @throws PassiveSTSException Error in logout url validation.
+     */
+    private void validateLogoutURL(HttpServletRequest request)
+            throws PassiveSTSException {
+
+        String wreplyFromReq = getAttribute(request.getParameterMap(), PassiveRequestorConstants.REPLY_TO);
+        if (StringUtils.isNotBlank(wreplyFromReq)) {
+            String configuredWreply = getConfiguredWreplyUrl(request);
+            if (!wreplyFromReq.equals(configuredWreply)) {
+                throw new PassiveSTSException("Provided wreply URL in the request does not match the configured " +
+                        "wreply logout url.");
+            }
+        }
+    }
+
+    /**
+     * Retrieve the configured wreply url from the service provider.
+     *
+     * @param request   Logout request.
+     * @return          Wreply url configured in the service provider.
+     * @throws PassiveSTSException Errors in retrieving the configured wreply url.
+     */
+    private String getConfiguredWreplyUrl(HttpServletRequest request) throws PassiveSTSException {
+
+        String wtrealm = getAttribute(request.getParameterMap(), PassiveRequestorConstants.REALM);
+        if (StringUtils.isBlank(wtrealm)) {
+            throw new PassiveSTSException("Missing parameter wtrealm in request.");
+        }
+        String tenantDomain = getTenantDomain(request);
+        ServiceProvider serviceProvider = getServiceProvider(wtrealm, tenantDomain);
+        Property[] properties = getInboundAuthConfigPropertiesFromSP(serviceProvider);
+        if (ArrayUtils.isNotEmpty(properties)) {
+            String wreplyUrl = null;
+            for (Property property : properties) {
+                if (PASSIVE_STS_W_REPLY_LOGOUT_PROPERTY.equalsIgnoreCase(property.getName())) {
+                    return property.getValue();
+                } else if (PASSIVE_STS_W_REPLY_PROPERTY.equalsIgnoreCase(property.getName())) {
+                    wreplyUrl = property.getValue();
+                }
+            }
+            // If the logout specific wreply url is not set, fallback to the wreply url.
+            if (StringUtils.isNotBlank(wreplyUrl)) {
+                return wreplyUrl;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the passive sts inbound authentication config properties from the service provider.
+     *
+     * @param serviceProvider   Service provider.
+     * @return                  Passive STS inbound authentication config properties.
+     */
+    private Property[] getInboundAuthConfigPropertiesFromSP(ServiceProvider serviceProvider) {
+
+        InboundAuthenticationRequestConfig[] inboundAuthenticationConfigs =
+                serviceProvider.getInboundAuthenticationConfig().getInboundAuthenticationRequestConfigs();
+        if (inboundAuthenticationConfigs != null) {
+            for (InboundAuthenticationRequestConfig inboundAuthenticationConfig : inboundAuthenticationConfigs) {
+                if (PASSIVE_STS_CLIENT_TYPE.equals(inboundAuthenticationConfig.getInboundAuthType())) {
+                    return inboundAuthenticationConfig.getProperties();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the passive sts service provider for the given realm.
+     *
+     * @param wtrealm       Realm of the service provider.
+     * @param tenantDomain  Tenant domain of the service provider.
+     * @return              Passive STS Service provider.
+     * @throws PassiveSTSException  Errors when getting the service provider.
+     */
+    private ServiceProvider getServiceProvider(String wtrealm, String tenantDomain) throws PassiveSTSException {
+
+        try {
+            ServiceProvider serviceProvider = ApplicationManagementService.getInstance()
+                    .getServiceProviderByClientId(wtrealm, PASSIVE_STS_CLIENT_TYPE, tenantDomain);
+            if (serviceProvider == null || IdentityApplicationConstants.DEFAULT_SP_CONFIG.equals(serviceProvider
+                    .getApplicationName())) {
+                throw new PassiveSTSException("Service provider for wtrealm: "  + wtrealm + " in tenant: "
+                        + tenantDomain + " is null or the default service provider.");
+            }
+            return serviceProvider;
+        } catch (IdentityApplicationManagementException e) {
+            throw new PassiveSTSException("Failed to retrieve service provider for wtrealm: " + wtrealm +
+                    " in tenant: " + tenantDomain);
+        }
+    }
+
+    /**
+     * Get tenant domain.
+     * @param request   HTTP request.
+     * @return          Tenant domain.
+     */
+    private String getTenantDomain(HttpServletRequest request) {
+
+        String tenantDomain;
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            tenantDomain = IdentityTenantUtil.resolveTenantDomain();
+        } else {
+            tenantDomain = getAttribute(request.getParameterMap(), MultitenantConstants.TENANT_DOMAIN);
+        }
+        if (StringUtils.isBlank(tenantDomain)) {
+            tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+        return tenantDomain;
     }
 
     /**
@@ -562,18 +695,25 @@ public class PassiveSTS extends HttpServlet {
                 if (PASSIVE_STS_CLIENT_TYPE.equals(inboundAuthenticationConfig.getInboundAuthType())) {
                     Property[] properties = inboundAuthenticationConfig.getProperties();
                     if (ArrayUtils.isNotEmpty(properties)) {
+                        String wreplyUrl = null;
                         for (Property property : properties) {
-                            if (PASSIVE_STS_W_REPLY_PROPERTY.equalsIgnoreCase(property.getName())) {
+                            if (PASSIVE_STS_W_REPLY_LOGOUT_PROPERTY.equalsIgnoreCase(property.getName())) {
                                 request.addParameter(PassiveRequestorConstants.REPLY_TO, property.getValue());
                                 break loop;
+                            } else if (PASSIVE_STS_W_REPLY_PROPERTY.equalsIgnoreCase(property.getName())) {
+                                wreplyUrl = property.getValue();
                             }
+                        }
+                        // If the logout specific wreply url is not set, fallback to the wreply url.
+                        if (StringUtils.isNotBlank(wreplyUrl)) {
+                            request.addParameter(PassiveRequestorConstants.REPLY_TO, wreplyUrl);
+                            break;
                         }
                     }
                 }
             }
         }
     }
-
     private void sendFrameworkForLogout(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException, PassiveSTSException {
 

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTS.java
@@ -714,6 +714,7 @@ public class PassiveSTS extends HttpServlet {
             }
         }
     }
+
     private void sendFrameworkForLogout(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException, PassiveSTSException {
 

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTSException.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/PassiveSTSException.java
@@ -26,4 +26,8 @@ public class PassiveSTSException extends IdentityException {
     public PassiveSTSException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public PassiveSTSException(String message) {
+        super(message);
+    }
 }

--- a/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/util/PassiveSTSUtil.java
+++ b/components/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/util/PassiveSTSUtil.java
@@ -19,9 +19,18 @@
 package org.wso2.carbon.identity.sts.passive.ui.util;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.sts.passive.ui.PassiveSTSException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URISyntaxException;
 
 public class PassiveSTSUtil {
 
@@ -32,5 +41,44 @@ public class PassiveSTSUtil {
         }
 
         return retryUrl;
+    }
+
+    /**
+     * Send user to the error page.
+     *
+     * @param request   Http servlet request.
+     * @param response  Http servlet response.
+     * @param status    Status to be displayed in the error page.
+     * @param statusMsg Status message to be displayed in the error page.
+     * @throws IOException          Error when sending the redirect.
+     * @throws PassiveSTSException  Error building the redirect url of the error page.
+     */
+    public static void sendToErrorPage(HttpServletRequest request, HttpServletResponse response, String status,
+                                       String statusMsg) throws IOException, PassiveSTSException {
+
+        String errorURL = getErrorURL(status, statusMsg);
+        String redirectURL = FrameworkUtils.getRedirectURL(errorURL, request);
+        response.sendRedirect(redirectURL);
+    }
+
+    /**
+     * Get the url of the error page.
+     *
+     * @param status        Status to be displayed in the error page.
+     * @param statusMsg     Status message to be displayed in the error page.
+     * @return              URL of the error page.
+     * @throws PassiveSTSException  Error building the redirect url of the error page.
+     */
+    private static String getErrorURL(String status, String statusMsg) throws PassiveSTSException {
+
+        try {
+            URIBuilder uriBuilder = new URIBuilder(
+                    ConfigurationFacade.getInstance().getAuthenticationEndpointErrorURL());
+            uriBuilder.addParameter(FrameworkConstants.STATUS_PARAM, status);
+            uriBuilder.addParameter(FrameworkConstants.STATUS_MSG_PARAM, statusMsg);
+            return uriBuilder.build().toString();
+        } catch (URISyntaxException e) {
+            throw new PassiveSTSException("Error building the redirect url of the error page.", e);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -505,6 +505,7 @@
         <carbon.consent.mgt.imp.pkg.version.range>[1.0.0, 3.0.0)</carbon.consent.mgt.imp.pkg.version.range>
         <cxf-bundle.version>3.5.5</cxf-bundle.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
+        <httpcomponents-httpclient.imp.pkg.version.range>[4.3.1.wso2v2,5.0.0)</httpcomponents-httpclient.imp.pkg.version.range>
 
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <joda.wso2.osgi.version.range>[2.8.2,3.0.0)</joda.wso2.osgi.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
     </build>
 
     <properties>
-        <identity.framework.version>5.25.380</identity.framework.version>
+        <identity.framework.version>5.25.491</identity.framework.version>
         <identity.inbound.auth.sts.package.export.version>${project.version}
         </identity.inbound.auth.sts.package.export.version>
         <inbound.auth.openid.version>5.6.0</inbound.auth.openid.version>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds validation for logout wreply url.

A new field is introduced in `WS-Federation (Passive) Configuration` in the SP to configure the logout wreply url, through https://github.com/wso2/carbon-identity-framework/pull/5129 and the url in the logout request will be validated against this. 

In order to reduce issues to existing users, if the logout wreply url config is left empty, there will be a fallback mechanism to validate the wreply url in the logout request against the existing Passive STS WReply URL.

### When should this PR be merged
This should be merged only after https://github.com/wso2/carbon-identity-framework/pull/5129 is merged.

