### PR TITLE
Upgrade xmlsec version to 2.3.4

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive/pom.xml
+++ b/components/org.wso2.carbon.identity.sts.passive/pom.xml
@@ -86,12 +86,12 @@
         <dependency>
             <groupId>org.apache.wss4j</groupId>
             <artifactId>wss4j-ws-security-common</artifactId>
-            <version>2.3.0</version>
+            <version>2.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.wss4j</groupId>
             <artifactId>wss4j-ws-security-dom</artifactId>
-            <version>2.3.0</version>
+            <version>2.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/components/org.wso2.carbon.identity.sts.passive/pom.xml
+++ b/components/org.wso2.carbon.identity.sts.passive/pom.xml
@@ -86,12 +86,12 @@
         <dependency>
             <groupId>org.apache.wss4j</groupId>
             <artifactId>wss4j-ws-security-common</artifactId>
-            <version>2.2.5</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.wss4j</groupId>
             <artifactId>wss4j-ws-security-dom</artifactId>
-            <version>2.2.5</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -458,10 +458,10 @@
         <carbon.kernel.version>4.7.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.7.0</carbon.kernel.feature.version>
         <carbon.xfer.package.version>4.2.0</carbon.xfer.package.version>
-        <xmlsec.version>2.1.7</xmlsec.version>
+        <xmlsec.version>2.3.4</xmlsec.version>
         <xmlsec.version.imp.pkg.version.range>[2.1.7,2.4.0)</xmlsec.version.imp.pkg.version.range>
-        <wss4j.version>1.5.11-wso2v23</wss4j.version>
-        <rampart.wso2.version>1.6.1-wso2v45</rampart.wso2.version>
+        <wss4j.version>1.5.11-wso2v24</wss4j.version>
+        <rampart.wso2.version>1.6.1-wso2v46</rampart.wso2.version>
         <opensaml2.wso2.version>2.6.6.wso2v6</opensaml2.wso2.version>
         <commons-fileupload.wso2.version>1.2.2.wso2v1</commons-fileupload.wso2.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>


### PR DESCRIPTION
### Proposed changes in this pull request

- Update xmlsec version to 2.3.4
- Update wss4j version to 1.5.11-wso2v24
- Update rampart version to 1.6.1-wso2v46
- Update wss4j-ws-security version to 2.3.0

### Related PR
https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/145
