### PR TITLE
Bump opensaml version to 3.3.1.wso2v11

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive/pom.xml
+++ b/components/org.wso2.carbon.identity.sts.passive/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.wso2.orbit.org.opensaml</groupId>
             <artifactId>opensaml</artifactId>
-            <version>3.3.1.wso2v7</version>
+            <version>3.3.1.wso2v11</version>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.logging</groupId>


### PR DESCRIPTION
### Proposed changes in this pull request
 - $suject
 - From this PR the below dependencies are upgraded in the opensaml orbit jar
     - apache commons codec version from 1.10 to 1.16
     - esapi.version from 2.4.0.0 to 2.5.3.1
     - org.apache.xml.security.version range