### PR TITLE
 Integrate IdentityKeyStoreResolver

### DIFF
--- a/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/utils/RequestProcessorUtil.java
+++ b/components/org.wso2.carbon.identity.sts.passive/src/main/java/org/wso2/carbon/identity/sts/passive/utils/RequestProcessorUtil.java
@@ -279,6 +279,11 @@ public class RequestProcessorUtil {
 
         String tenantKeyStoreName = IdentityKeyStoreResolverUtil.buildTenantKeyStoreName(tenantDomain);
 
+        if (StringUtils.isEmpty(keyStoreFileLocation) || StringUtils.isEmpty(keyStorePassword)) {
+            throw new STSException("Error occoured when building encryption properties." +
+                    " One or more keystore properties are null or empty.");
+        }
+
         Properties properties = new Properties();
 
         properties.put("org.apache.wss4j.crypto.provider",

--- a/pom.xml
+++ b/pom.xml
@@ -455,7 +455,7 @@
         </identity.inbound.auth.sts.package.export.version>
         <inbound.auth.openid.version>5.6.0</inbound.auth.openid.version>
 
-        <carbon.kernel.version>4.9.23</carbon.kernel.version>
+        <carbon.kernel.version>4.10.19</carbon.kernel.version>
         <carbon.kernel.feature.version>4.7.0</carbon.kernel.feature.version>
         <carbon.xfer.package.version>4.2.0</carbon.xfer.package.version>
         <xmlsec.version>2.3.4</xmlsec.version>


### PR DESCRIPTION
# Purpose
- This PR integrates the `IdentityKeyStoreResolver` class into the WS-Federation and WS-Trust flows.
- This will allow users to define custom key stores for each authentication flow.
# Important
- Following PRs should be merged before merging this PR,
  - https://github.com/wso2/carbon-kernel/pull/4025
  - https://github.com/wso2/carbon-identity-framework/pull/5794
---
- Problem Statement: https://github.com/wso2-enterprise/iam-product-management/issues/67
- Public Git Issue: https://github.com/wso2/product-is/issues/20564