### PR TITLE
Fixed userstore resolving logic for tenant

### DIFF
--- a/components/org.wso2.carbon.security.sts.common/src/main/java/org/wso2/carbon/identity/sts/common/identity/provider/AttributeCallbackHandler.java
+++ b/components/org.wso2.carbon.security.sts.common/src/main/java/org/wso2/carbon/identity/sts/common/identity/provider/AttributeCallbackHandler.java
@@ -159,17 +159,19 @@ public class AttributeCallbackHandler implements SAMLCallbackHandler {
                                     StringUtils.isNotBlank(remoteClaimPrefixValue)) {
                                 // WS trust flow does not set the authenticated user property.
                                 if (isHandlerCalledFromWSTrustSTSFlow(attrCallback)) {
-                                    localClaimValue = IdentityProviderSTSServiceComponent.getRealmService().
-                                            getBootstrapRealm().getUserStoreManager().
-                                            getUserClaimValue(userIdentifier, localClaimUri, DEFAULT_PROFILE);
+                                    tenantDomain = getTenantDomainFromThreadLocalContext();
+                                    UserRealm userRealm = IdentityTenantUtil.getRealm(tenantDomain, null);
+                                    localClaimValue = userRealm.getUserStoreManager().getUserClaimValue(userIdentifier,
+                                            localClaimUri, DEFAULT_PROFILE);
                                 } else if (!authenticatedUser.isFederatedUser()) {
                                     if (log.isDebugEnabled()) {
                                         log.debug("Loading claim values from local UserStore for user: "
                                                 + authenticatedUser.toString());
                                     }
-                                    localClaimValue = IdentityProviderSTSServiceComponent.getRealmService().
-                                            getBootstrapRealm().getUserStoreManager().
-                                            getUserClaimValue(userIdentifier, localClaimUri, DEFAULT_PROFILE);
+                                    tenantDomain = getTenantDomainFromThreadLocalContext();
+                                    UserRealm userRealm = IdentityTenantUtil.getRealm(tenantDomain, null);
+                                    localClaimValue = userRealm.getUserStoreManager().getUserClaimValue(userIdentifier,
+                                            localClaimUri, DEFAULT_PROFILE);
                                 }
 
                                 if (StringUtils.isEmpty(localClaimValue)) {
@@ -188,7 +190,7 @@ public class AttributeCallbackHandler implements SAMLCallbackHandler {
                     }
                 } catch (IdentityApplicationManagementException e) {
                     throw new SAMLException("Error while loading SP specific claims", e);
-                } catch (org.wso2.carbon.user.core.UserStoreException e) {
+                } catch (org.wso2.carbon.user.core.UserStoreException | IdentityException e) {
                     throw new SAMLException("Error while loading claims of the user", e);
                 }
             }


### PR DESCRIPTION
### Proposed changes in this pull request
- https://github.com/wso2/product-is/issues/21833

This pull request includes changes to the `AttributeCallbackHandler.java` file to improve the handling of user claims and error scenarios. The most important changes include updating the method for obtaining the `UserRealm` and adding an additional catch block for `IdentityException`.

Improvements to user claims handling:

* [`components/org.wso2.carbon.security.sts.common/src/main/java/org/wso2/carbon/identity/sts/common/identity/provider/AttributeCallbackHandler.java`](diffhunk://#diff-3de20f13918eb1902e6bd26e1a751433aedd3a3f636f9fcc6f74f3053fca406cL161-R173): Updated the method for obtaining the `UserRealm` by using `IdentityTenantUtil.getRealm` with the tenant domain obtained from the thread local context. This change ensures that the correct tenant domain is used when retrieving user claims.

Error handling enhancements:

* [`components/org.wso2.carbon.security.sts.common/src/main/java/org/wso2/carbon/identity/sts/common/identity/provider/AttributeCallbackHandler.java`](diffhunk://#diff-3de20f13918eb1902e6bd26e1a751433aedd3a3f636f9fcc6f74f3053fca406cR194-R195): Added a new catch block for `IdentityException` to handle additional error scenarios when loading claims. This improves the robustness of the error handling in the `handle` method.