### PR TITLE
[5.11 - Connector Release] Add support for configure custom keystores for ws-trust and ws-fed

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-m2
         with:

--- a/components/org.wso2.carbon.security.sts.common/src/main/java/org/wso2/carbon/identity/sts/common/config/SecurityConfigAdmin.java
+++ b/components/org.wso2.carbon.security.sts.common/src/main/java/org/wso2/carbon/identity/sts/common/config/SecurityConfigAdmin.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.sts.common.config;
@@ -57,6 +59,11 @@ import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.core.util.CryptoUtil;
 import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.core.util.KeyStoreUtil;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
+import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants;
+import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.sts.common.SecurityConfigParams;
 import org.wso2.carbon.identity.sts.common.SecurityScenario;
@@ -560,6 +567,21 @@ public class SecurityConfigAdmin {
         }
         // First disable security and remove all applied policies before applying a new policy
         this.disableSecurityOnService(serviceName);
+
+        // Override keystore settings with custom WS-Trust specific keystore configuration
+        // if available for the tenant.
+        try {
+            String tenantDomain = IdentityTenantUtil.getTenantDomain(((UserRegistry) registry).getTenantId());
+            String keyStoreName = IdentityKeyStoreResolver.getInstance()
+                    .getKeyStoreName(tenantDomain, IdentityKeyStoreResolverConstants.InboundProtocol.WS_TRUST);
+            if (KeyStoreUtil.isCustomKeyStore(keyStoreName)) {
+                privateStore = keyStoreName;
+                trustedStores = new String[] {keyStoreName};
+            }
+        } catch (IdentityKeyStoreResolverException | IdentityRuntimeException e) {
+            String msg = "Error while retrieving the keystore configurations for the tenant";
+            throw new SecurityConfigException(msg, e);
+        }
 
         OMElement policyElement = loadPolicyAsXML(scenarioId, policyPath);
         SecurityScenario scenario = SecurityScenarioDatabase.get(scenarioId);

--- a/components/org.wso2.carbon.security.sts.common/src/main/java/org/wso2/carbon/identity/sts/common/util/ServicePasswordCallbackHandler.java
+++ b/components/org.wso2.carbon.security.sts.common/src/main/java/org/wso2/carbon/identity/sts/common/util/ServicePasswordCallbackHandler.java
@@ -1,21 +1,26 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.sts.common.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -24,6 +29,9 @@ import org.wso2.carbon.core.RegistryResources;
 import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.core.util.CryptoUtil;
 import org.wso2.carbon.core.util.KeyStoreManager;
+import org.wso2.carbon.core.util.KeyStoreUtil;
+import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
+import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.sts.common.SecurityConfigParams;
 import org.wso2.carbon.identity.sts.common.UserCredentialRetriever;
@@ -419,6 +427,20 @@ public class ServicePasswordCallbackHandler implements CallbackHandler {
                         }
                     }
 
+                }
+            }
+
+            // If the custom keystore is configured check for the password within the custom keystore.
+            String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
+            String keyStoreName = IdentityKeyStoreResolver.getInstance()
+                    .getKeyStoreName(tenantDomain, IdentityKeyStoreResolverConstants.InboundProtocol.WS_TRUST);
+            if (KeyStoreUtil.isCustomKeyStore(keyStoreName)) {
+                KeyStore keyStore = IdentityKeyStoreResolver.getInstance()
+                        .getKeyStore(tenantDomain, IdentityKeyStoreResolverConstants.InboundProtocol.WS_TRUST);
+                if (keyStore.containsAlias(username)) {
+                    password = IdentityKeyStoreResolver.getInstance()
+                            .getKeyStoreConfig(tenantDomain, IdentityKeyStoreResolverConstants.InboundProtocol.WS_TRUST,
+                                    RegistryResources.SecurityManagement.CustomKeyStore.PROP_PASSWORD);
                 }
             }
         } catch (IOException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.core</artifactId>
-                <version>${identity.framework.version}</version>
+                <version>${identity.framework.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -448,7 +448,8 @@
     </build>
 
     <properties>
-        <identity.framework.version>7.8.101</identity.framework.version>
+        <identity.framework.version>5.25.305</identity.framework.version>
+        <identity.framework.core.version>7.8.101</identity.framework.core.version>
         <identity.inbound.auth.sts.package.export.version>${project.version}
         </identity.inbound.auth.sts.package.export.version>
         <inbound.auth.openid.version>5.6.0</inbound.auth.openid.version>

--- a/pom.xml
+++ b/pom.xml
@@ -448,12 +448,12 @@
     </build>
 
     <properties>
-        <identity.framework.version>5.25.305</identity.framework.version>
+        <identity.framework.version>7.8.101</identity.framework.version>
         <identity.inbound.auth.sts.package.export.version>${project.version}
         </identity.inbound.auth.sts.package.export.version>
         <inbound.auth.openid.version>5.6.0</inbound.auth.openid.version>
 
-        <carbon.kernel.version>4.7.0</carbon.kernel.version>
+        <carbon.kernel.version>4.10.37</carbon.kernel.version>
         <carbon.kernel.feature.version>4.7.0</carbon.kernel.feature.version>
         <carbon.xfer.package.version>4.2.0</carbon.xfer.package.version>
         <xmlsec.version>2.3.4</xmlsec.version>


### PR DESCRIPTION
### Changes
This PR introduces the necessary changes to support configuring a custom keystores for the WS-Trust/WS-Fed protocols. It updates all relevant areas where keystores are used. If a custom keystore is not configured, the system will fall back to the default primary or tenanted keystore.

To configure a custom keystore, use the following TOML configuration:

```toml
[[keystore.custom]]
file_name = "custom.p12"
password = "password"
type = "PKCS12"
alias = "myOrgCert"
key_password = "password"

[keystore.mapping.ws_trust]
keystore_file_name = "custom.p12"
use_in_all_tenants = true

[keystore.mapping.ws_federation]
keystore_file_name = "custom.p12"
use_in_all_tenants = true
```

### Related Issue
- https://github.com/wso2/product-is/issues/20564

### Master PR
- https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/187
