### PR TITLE
Revert connector version change for 7.1

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -8,7 +8,7 @@
     "labels": ["Inbound Authenticator", "Security Token Service"],
     "releases": [
         {
-            "tagName": "v5.12.9",
+            "tagName": "v5.12.1",
             "products": [
                 "IS 7.1.0"
             ]


### PR DESCRIPTION
### Purpose

Since custom keystore support has been merged into the master branch, the changes will be available in the IS 7.2.0 release. Therefore, we do not need to include this change in the connector for 7.1 product. This PR reverts the version bump introduced in [1]. The changes will be tracked and verified with the 7.2 connector release through issue [2].

[1] - https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/189
[2] - https://github.com/wso2/product-is/issues/24047